### PR TITLE
Add an extensible GenerateTilesOptions struct for invoking the tile.GenerateTiles method

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -149,7 +149,7 @@ func main() {
 	gzipEnabled := flag.Bool("gzip", false, "Request gzip encoding from server and store gzipped contents in mbtiles. Will gzip locally if server doesn't do it.")
 	requestTimeout := flag.Int("timeout", 60, "HTTP client timeout for tile requests.")
 	cpuProfile := flag.String("cpuprofile", "", "Enables CPU profiling. Saves the dump to the given path.")
-	invertedY := flag.Bool("inverted-y", false, "...")
+	invertedY := flag.Bool("inverted-y", false, "Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.")
 	flag.Parse()
 
 	if *cpuProfile != "" {
@@ -250,7 +250,7 @@ func main() {
 		}
 	}
 
-	opts := tilepack.GenerateTilesOptions{
+	opts := &tilepack.GenerateTilesOptions{
 		Bounds:       bounds,
 		Zooms:        zooms,
 		ConsumerFunc: consumer,

--- a/tilepack/tile.go
+++ b/tilepack/tile.go
@@ -128,14 +128,15 @@ func GenerateTiles(opts *GenerateTilesOptions) {
 			for i := llx; i < min(ur.X+1, 1<<z); i++ {
 				for j := ury; j < min(ll.Y+1, 1<<z); j++ {
 
+					x := i
+					y := j
+
 					if opts.InvertedY {
 						// https://gist.github.com/tmcw/4954720
-						inverted := uint(math.Pow(2.0, float64(z)))
-						inverted = inverted - 1 - j
-						j = inverted
+						y = uint(math.Pow(2.0, float64(z))) - 1 - y
 					}
 
-					consumer(&Tile{Z: z, X: i, Y: j})
+					consumer(&Tile{Z: z, X: x, Y: y})
 				}
 			}
 		}


### PR DESCRIPTION
* Add an extensible `GenerateTilesOptions` struct for invoking the `tile.GenerateTiles` method, replacing positional arguments
* Add a `GenerateTilesConsumerFunc` type
* Add a `-inverted-y` command line flag to signal that the Y-value for tiles should follow the TMS (rather than ZXY) format

I think the MBTiles spec default to `TMS` so maybe the `-inverted-y` flag should default to true? Currently it defaults to false to match the program's existing behaviour.
