### PR TITLE
Add support for a "disk" outputter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-fmt:
-	go fmt ./...
-
 tools:
-	go build -o bin/build cmd/build/main.go
-	go build -o bin/serve cmd/serve/main.go
+	go build -mod vendor -o bin/build cmd/build/main.go
+	go build -mod vendor -o bin/serve cmd/serve/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+fmt:
+	go fmt ./...
+
 tools:
 	go build -o bin/build cmd/build/main.go
 	go build -o bin/serve cmd/serve/main.go

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage of ./bin/build:
     	Request gzip encoding from server and store gzipped contents in mbtiles. Will gzip locally if server doesn't do it.
   -inverted-y
     	Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.
-  -mode string
+  -output-mode string
     	Valid modes are: disk, mbtiles. (default "mbtiles")
   -timeout int
     	HTTP client timeout for tile requests. (default 60)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # go-tilepacks
+
 A Go-based tile downloader that saves to deduplicated mbtiles files.
+
+## Tools
+
+### build
+
+```
+> ./bin/build -h
+Usage of ./bin/build:
+  -bounds string
+    	Comma-separated bounding box in south,west,north,east format. Defaults to the whole world. (default "-90.0,-180.0,90.0,180.0")
+  -cpuprofile string
+    	Enables CPU profiling. Saves the dump to the given path.
+  -dsn string
+    	Path, or DSN string, to output files.
+  -gzip
+    	Request gzip encoding from server and store gzipped contents in mbtiles. Will gzip locally if server doesn't do it.
+  -inverted-y
+    	Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.
+  -mode string
+    	Valid modes are: disk, mbtiles. (default "mbtiles")
+  -output string
+    	Path, or DSN string, to output files. DEPRECATED - please use -dsn instead.
+  -timeout int
+    	HTTP client timeout for tile requests. (default 60)
+  -url string
+    	URL template to make tile requests with.
+  -workers int
+    	Number of HTTP client workers to use. (default 25)
+  -zooms string
+    	Comma-separated list of zoom levels. (default "0,1,2,3,4,5,6,7,8,9,10")
+```
+
+#### Outputters
+
+The following tile "outputter" are supported, as defined by the `-mode` flag:
+
+##### disk
+
+Clone tiles to a local directory. Valid `-dsn` strings must be in the form of:
+
+```
+-dsn 'root={PATH_TO_DIRECTORY_ROOT} format={TILE_FORMAT}'
+```
+
+
+##### mbtiles
+
+Clone tiles to a MBTiles (SQLite) database. Valid `-dsn` strings must be in the form of:
+
+```
+-dsn {PATH_TO_MBTILES_DATABASE}
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-tilepacks
 
-A Go-based tile downloader that saves to deduplicated mbtiles files.
+A Go-based tile downloader that saves to deduplicated files.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Usage of ./bin/build:
     	Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.
   -mode string
     	Valid modes are: disk, mbtiles. (default "mbtiles")
-  -output string
-    	Path, or DSN string, to output files. DEPRECATED - please use -dsn instead.
   -timeout int
     	HTTP client timeout for tile requests. (default 60)
   -url string

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -172,7 +172,7 @@ func processResults(waitGroup *sync.WaitGroup, results chan *TileResponse, proce
 func main() {
 	urlTemplateStr := flag.String("url", "", "URL template to make tile requests with.")
 	outputMode := flag.String("mode", "mbtiles", "Valid modes are: disk, mbtiles.")
-	outputDSN := flag.String("dsn", "", "Path, or DSN string, to output files.")	
+	outputDSN := flag.String("dsn", "", "Path, or DSN string, to output files.")
 	boundingBoxStr := flag.String("bounds", "-90.0,-180.0,90.0,180.0", "Comma-separated bounding box in south,west,north,east format. Defaults to the whole world.")
 	zoomsStr := flag.String("zooms", "0,1,2,3,4,5,6,7,8,9,10", "Comma-separated list of zoom levels.")
 	numHTTPWorkers := flag.Int("workers", 25, "Number of HTTP client workers to use.")
@@ -265,7 +265,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create %s output: %+v", *outputMode, err)
 	}
-	
+
 	log.Printf("Created %s output\n", *outputMode)
 
 	jobs := make(chan *TileRequest, 2000)

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -171,7 +171,7 @@ func processResults(waitGroup *sync.WaitGroup, results chan *TileResponse, proce
 
 func main() {
 	urlTemplateStr := flag.String("url", "", "URL template to make tile requests with.")
-	outputMode := flag.String("mode", "mbtiles", "Valid modes are: disk, mbtiles.")
+	outputMode := flag.String("output-mode", "mbtiles", "Valid modes are: disk, mbtiles.")
 	outputDSN := flag.String("dsn", "", "Path, or DSN string, to output files.")
 	boundingBoxStr := flag.String("bounds", "-90.0,-180.0,90.0,180.0", "Comma-separated bounding box in south,west,north,east format. Defaults to the whole world.")
 	zoomsStr := flag.String("zooms", "0,1,2,3,4,5,6,7,8,9,10", "Comma-separated list of zoom levels.")

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -147,7 +147,6 @@ func processResults(waitGroup *sync.WaitGroup, results chan *TileResponse, proce
 func main() {
 	urlTemplateStr := flag.String("url", "", "URL template to make tile requests with.")
 	outputMode := flag.String("mode", "mbtiles", "Valid modes are: disk, mbtiles.")
-	outputStr := flag.String("output", "", "Path, or DSN string, to output files. DEPRECATED - please use -dsn instead.")
 	outputDSN := flag.String("dsn", "", "Path, or DSN string, to output files.")	
 	boundingBoxStr := flag.String("bounds", "-90.0,-180.0,90.0,180.0", "Comma-separated bounding box in south,west,north,east format. Defaults to the whole world.")
 	zoomsStr := flag.String("zooms", "0,1,2,3,4,5,6,7,8,9,10", "Comma-separated list of zoom levels.")
@@ -158,10 +157,6 @@ func main() {
 	invertedY := flag.Bool("inverted-y", false, "Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.")
 	flag.Parse()
 
-	if *outputDSN == "" {
-		*outputDSN = *outputStr
-	}
-	
 	if *cpuProfile != "" {
 		f, err := os.Create(*cpuProfile)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/tilezen/go-tilepacks
 
-go 1.12
+require (
+	github.com/aaronland/go-string v0.1.0
+	github.com/mattn/go-sqlite3 v1.10.0
+)
 
-require github.com/mattn/go-sqlite3 v1.10.0
+go 1.12

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/aaronland/go-string v0.1.0 h1:HU6OHmEpN2m9b5SOIwU6HoOq87Fvemj/0g6DTp8yzpk=
+github.com/aaronland/go-string v0.1.0/go.mod h1:2aMIWdTqk63jZsaLLy+p9dsB1MDRqx4sHYoLtkwyYUo=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=

--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -23,9 +23,9 @@ func NewDiskOutputter(dsn_str string) (*diskOutputter, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	abs_root, err := filepath.Abs(dsn_map["root"])
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -3,6 +3,8 @@ package tilepack
 import (
 	"errors"
 	"fmt"
+	"github.com/aaronland/go-string/dsn"
+	_ "log"
 	"os"
 	"path/filepath"
 )
@@ -14,19 +16,23 @@ type diskOutputter struct {
 	hasTiles bool
 }
 
-func NewDiskOutputter(dsn string) (*diskOutputter, error) {
+func NewDiskOutputter(dsn_str string) (*diskOutputter, error) {
 
-	format := "svg" // FIX ME
+	dsn_map, err := dsn.StringToDSNWithKeys(dsn_str, "root", "format")
 
-	root, err := filepath.Abs(dsn)
-
+	if err != nil {
+		return nil, err
+	}
+	
+	abs_root, err := filepath.Abs(dsn_map["root"])
+	
 	if err != nil {
 		return nil, err
 	}
 
 	o := diskOutputter{
-		root:   root,
-		format: format,
+		root:   abs_root,
+		format: dsn_map["format"],
 	}
 
 	return &o, nil

--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -96,11 +96,10 @@ func (o *diskOutputter) Save(tile *Tile, data []byte) error {
 		return err
 	}
 
-	defer fh.Close()
-
 	_, err = fh.Write(data)
 
 	if err != nil {
+		fh.Close()
 		return err
 	}
 

--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -8,8 +8,9 @@ import (
 )
 
 type diskOutputter struct {
+	TileOutputter
 	root     string
-	format	string
+	format   string
 	hasTiles bool
 }
 
@@ -24,10 +25,10 @@ func NewDiskOutputter(dsn string) (*diskOutputter, error) {
 	}
 
 	o := diskOutputter{
-		root: root,
+		root:   root,
 		format: format,
 	}
-	
+
 	return &o, nil
 }
 

--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -1,0 +1,101 @@
+package tilepack
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type diskOutputter struct {
+	root     string
+	format	string
+	hasTiles bool
+}
+
+func NewDiskOutputter(dsn string) (*diskOutputter, error) {
+
+	format := "svg" // FIX ME
+
+	root, err := filepath.Abs(dsn)
+
+	if err != nil {
+		return nil, err
+	}
+
+	o := diskOutputter{
+		root: root,
+		format: format,
+	}
+	
+	return &o, nil
+}
+
+func (o *diskOutputter) Close() error {
+	return nil
+}
+
+func (o *diskOutputter) CreateTiles() error {
+	if o.hasTiles {
+		return nil
+	}
+
+	info, err := os.Stat(o.root)
+
+	if err != nil {
+
+		if os.IsNotExist(err) {
+
+			err := os.MkdirAll(o.root, 0755)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+
+	} else {
+
+		if !info.IsDir() {
+			return errors.New("Root is already a file")
+		}
+	}
+
+	o.hasTiles = true
+	return nil
+}
+
+func (o *diskOutputter) Save(tile *Tile, data []byte) error {
+
+	rel_path := fmt.Sprintf("%d/%d/%d.%s", tile.Z, tile.X, tile.Y, o.format)
+	abs_path := filepath.Join(o.root, rel_path)
+
+	root := filepath.Dir(abs_path)
+
+	_, err := os.Stat(root)
+
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(root, 0755)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fh, err := os.OpenFile(abs_path, os.O_RDWR|os.O_CREATE, 0644)
+
+	if err != nil {
+		return err
+	}
+
+	defer fh.Close()
+
+	_, err = fh.Write(data)
+
+	if err != nil {
+		return err
+	}
+
+	return fh.Close()
+}

--- a/tilepack/mbtiles_outputter.go
+++ b/tilepack/mbtiles_outputter.go
@@ -22,6 +22,7 @@ func NewMbtilesOutputter(dsn string) (*mbtilesOutputter, error) {
 }
 
 type mbtilesOutputter struct {
+	TileOutputter
 	db         *sql.DB
 	txn        *sql.Tx
 	batchCount int

--- a/tilepack/outputter.go
+++ b/tilepack/outputter.go
@@ -1,6 +1,7 @@
 package tilepack
 
 type TileOutputter interface {
+	CreateTiles() error
 	Save(tile *Tile, data []byte) error
 	Close() error
 }

--- a/vendor/github.com/aaronland/go-string/LICENSE
+++ b/vendor/github.com/aaronland/go-string/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2018, Aaron Straup Cope
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/aaronland/go-string/dsn/dsn.go
+++ b/vendor/github.com/aaronland/go-string/dsn/dsn.go
@@ -1,0 +1,85 @@
+package dsn
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type DSN map[string]string
+
+func (dsn DSN) Keys() []string {
+
+	keys := make([]string, 0)
+
+	for k, _ := range dsn {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	return keys
+}
+
+func (dsn DSN) String() string {
+
+	pairs := make([]string, 0)
+
+	for _, k := range dsn.Keys() {
+
+		pair := fmt.Sprintf("%s=%s", k, dsn[k])
+		pairs = append(pairs, pair)
+	}
+
+	return strings.Join(pairs, " ")
+}
+
+func StringToDSN(str_dsn string) (DSN, error) {
+
+	str_dsn = strings.Trim(str_dsn, " ")
+	dsn := make(map[string]string)
+
+	for _, str_pair := range strings.Split(str_dsn, " ") {
+
+		pair := strings.Split(str_pair, "=")
+
+		if len(pair) != 2 {
+			return nil, errors.New("Invalid DSN string")
+		}
+
+		k := pair[0]
+		v := pair[1]
+
+		_, ok := dsn[k]
+
+		if ok {
+			msg := fmt.Sprintf("'%s' key already set", k)
+			return nil, errors.New(msg)
+		}
+
+		dsn[k] = v
+	}
+
+	return dsn, nil
+}
+
+func StringToDSNWithKeys(str_dsn string, keys ...string) (DSN, error) {
+
+	dsn, err := StringToDSN(str_dsn)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, k := range keys {
+
+		_, ok := dsn[k]
+
+		if !ok {
+			msg := fmt.Sprintf("DSN is missing '%s=' key", k)
+			return nil, errors.New(msg)
+		}
+	}
+
+	return dsn, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,2 +1,4 @@
+# github.com/aaronland/go-string v0.1.0
+github.com/aaronland/go-string/dsn
 # github.com/mattn/go-sqlite3 v1.10.0
 github.com/mattn/go-sqlite3


### PR DESCRIPTION
* Add `tilepack/disk_outputter.go` to clone files to a local directory tree
* Update `tilepack.Outputter` interface to include a `CreateTiles()` method
* Deprecate the `-output` flag in favour of `-dsn` to allow complex per-outputter output definitions
* Add a `-mode` flag to define outputter
* Basic documentation for `cmd/build` in README