### PR TITLE
Move tile handler in cmd/serve in to a standalone package.

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	if err := server.ListenAndServe(); err != nil && err != gohttp.ErrServerClosed {
-		logger.Fatalf("Could not listen on %s: %v\n", addr, err)
+		logger.Fatalf("Could not listen on %s: %v\n", *addr, err)
 	}
 
 }

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -2,85 +2,18 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
+	gohttp "net/http"
 	"os"
-	"regexp"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/tilezen/go-tilepacks/http"
 	"github.com/tilezen/go-tilepacks/tilepack"
 )
 
-type MbtilesHandler struct {
-	mbtiles tilepack.MbtilesReader
-}
-
-var (
-	tilezenRegex = regexp.MustCompile(`^\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
-)
-
-func NewMbtilesHandler(filename string) (*MbtilesHandler, error) {
-	reader, err := tilepack.NewMbtilesReader(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	return &MbtilesHandler{
-		mbtiles: reader,
-	}, nil
-}
-
-func parseTileFromPath(url string) (*tilepack.Tile, error) {
-	match := tilezenRegex.FindStringSubmatch(url)
-	if match == nil {
-		return nil, fmt.Errorf("invalid tile path")
-	}
-
-	z, _ := strconv.ParseUint(match[1], 10, 32)
-	x, _ := strconv.ParseUint(match[2], 10, 32)
-	y, _ := strconv.ParseUint(match[3], 10, 32)
-
-	return &tilepack.Tile{Z: uint(z), X: uint(x), Y: uint(y)}, nil
-}
-
-func (o *MbtilesHandler) TilesHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		requestedTile, err := parseTileFromPath(r.URL.Path)
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
-
-		result, err := o.mbtiles.GetTile(requestedTile)
-		if err != nil {
-			log.Printf("Error getting tile: %+v", err)
-			http.NotFound(w, r)
-			return
-		}
-
-		if result.Data == nil {
-			http.NotFound(w, r)
-			return
-		}
-
-		acceptEncoding := r.Header.Get("Accept-Encoding")
-		if strings.Contains(acceptEncoding, "gzip") {
-			w.Header().Set("Content-Encoding", "gzip")
-		} else {
-			log.Printf("Requester doesn't accept gzip but our mbtiles have gzip in them")
-		}
-
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.Write(*result.Data)
-	}
-}
-
-func loggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func loggingMiddleware(logger *log.Logger) func(gohttp.Handler) gohttp.Handler {
+	return func(next gohttp.Handler) gohttp.Handler {
+		return gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
 			defer func() {
 				logger.Println(r.Method, r.URL.Path, r.RemoteAddr, r.UserAgent())
 			}()
@@ -100,17 +33,19 @@ func main() {
 		logger.Fatal("Need to provide --input parameter")
 	}
 
-	mbtilesHandler, err := NewMbtilesHandler(*mbtilesFile)
+	reader, err := tilepack.NewMbtilesReader(*mbtilesFile)
 	if err != nil {
-		logger.Fatalf("Couldn't create mbtiles handler: %+v", err)
+		logger.Fatalf("Couldn't create MBtilesReader, %v", err)
 	}
 
-	router := http.NewServeMux()
+	mbtilesHandler := http.MbtilesHandler(reader)
+
+	router := gohttp.NewServeMux()
 	router.HandleFunc("/preview.html", previewHTMLHandler)
-	router.Handle("/tilezen/", mbtilesHandler.TilesHandler())
+	router.Handle("/tilezen/", mbtilesHandler)
 	router.HandleFunc("/", defaultHandler)
 
-	server := &http.Server{
+	server := &gohttp.Server{
 		Addr:         *addr,
 		Handler:      loggingMiddleware(logger)(router),
 		ErrorLog:     logger,
@@ -119,16 +54,16 @@ func main() {
 		IdleTimeout:  30 * time.Second,
 	}
 
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := server.ListenAndServe(); err != nil && err != gohttp.ErrServerClosed {
 		logger.Fatalf("Could not listen on %s: %v\n", addr, err)
 	}
 
 }
 
-func previewHTMLHandler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "cmd/serve/static/preview.html")
+func previewHTMLHandler(w gohttp.ResponseWriter, r *gohttp.Request) {
+	gohttp.ServeFile(w, r, "cmd/serve/static/preview.html")
 }
 
-func defaultHandler(w http.ResponseWriter, r *http.Request) {
-	http.NotFound(w, r)
+func defaultHandler(w gohttp.ResponseWriter, r *gohttp.Request) {
+	gohttp.NotFound(w, r)
 }

--- a/http/mbtiles.go
+++ b/http/mbtiles.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"fmt"
+	"github.com/tilezen/go-tilepacks/tilepack"
+	"log"
+	gohttp "net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	tilezenRegex = regexp.MustCompile(`^\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
+)
+
+func MBTilesTilesHandler(reader tilepack.MbtilesReader) gohttp.HandlerFunc {
+
+	return func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		requestedTile, err := parseTileFromPath(r.URL.Path)
+		if err != nil {
+			gohttp.NotFound(w, r)
+			return
+		}
+
+		result, err := reader.GetTile(requestedTile)
+		if err != nil {
+			log.Printf("Error getting tile: %+v", err)
+			gohttp.NotFound(w, r)
+			return
+		}
+
+		if result.Data == nil {
+			gohttp.NotFound(w, r)
+			return
+		}
+
+		acceptEncoding := r.Header.Get("Accept-Encoding")
+		if strings.Contains(acceptEncoding, "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+		} else {
+			log.Printf("Requester doesn't accept gzip but our mbtiles have gzip in them")
+		}
+
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Write(*result.Data)
+	}
+}
+
+func parseTileFromPath(url string) (*tilepack.Tile, error) {
+	match := tilezenRegex.FindStringSubmatch(url)
+	if match == nil {
+		return nil, fmt.Errorf("invalid tile path")
+	}
+
+	z, _ := strconv.ParseUint(match[1], 10, 32)
+	x, _ := strconv.ParseUint(match[2], 10, 32)
+	y, _ := strconv.ParseUint(match[3], 10, 32)
+
+	return &tilepack.Tile{Z: uint(z), X: uint(x), Y: uint(y)}, nil
+}

--- a/http/mbtiles.go
+++ b/http/mbtiles.go
@@ -14,7 +14,7 @@ var (
 	tilezenRegex = regexp.MustCompile(`^\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
 )
 
-func MBTilesTilesHandler(reader tilepack.MbtilesReader) gohttp.HandlerFunc {
+func MbtilesHandler(reader tilepack.MbtilesReader) gohttp.HandlerFunc {
 
 	return func(w gohttp.ResponseWriter, r *gohttp.Request) {
 		requestedTile, err := parseTileFromPath(r.URL.Path)


### PR DESCRIPTION
This PR moves the tile handler function in `cmd/serve` in to its own `http/mbtiles.go` package.