### PR TITLE
Correct the gzip handling

### DIFF
--- a/tilepack/http_job_creator.go
+++ b/tilepack/http_job_creator.go
@@ -151,8 +151,11 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 
 			switch contentEncoding {
 			case "gzip":
-
-				// Reset at the top in case we ran into a continue below
+				// If the server reports content encoding of gzip, we can just copy the bytes as-is
+				bodyData, err = ioutil.ReadAll(resp.Body)
+			default:
+				// Otherwise we'll gzip the data, so we should
+				// reset at the top in case we ran into a continue below
 				bodyBuffer.Reset()
 				bodyGzipper.Reset(bodyBuffer)
 
@@ -173,8 +176,6 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 					log.Printf("Couldn't read bytes into byte array: %+v", err)
 					continue
 				}
-			default:
-				bodyData, err = ioutil.ReadAll(resp.Body)
 			}
 			resp.Body.Close()
 


### PR DESCRIPTION
Fixes #16

This fixes a logic bug in the code that saves data from HTTP responses where we would re-gzip already gzipped data from the server.

The goal of this bit of code was to always store gzipped data in mbtiles. We ask the server to give us a gzipped response. If the response is gzipped, we save those bytes exactly. If it's not gzipped (usually because the response is too small), then we gzip it ourselves and store it.