### PR TITLE
Allow for alternative prefixes; Allow liberal bbox strings

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -87,6 +87,7 @@ func main() {
 
 	boundingBoxFloats := make([]float64, 4)
 	for i, bboxStr := range boundingBoxStrSplit {
+		bboxStr = strings.TrimSpace(bboxStr)
 		bboxFloat, err := strconv.ParseFloat(bboxStr, 64)
 		if err != nil {
 			log.Fatalf("Bounding box string could not be parsed as numbers")

--- a/http/mbtiles.go
+++ b/http/mbtiles.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	tilezenRegex = regexp.MustCompile(`^\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
+	tilezenRegex = regexp.MustCompile(`\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
 )
 
 func MbtilesHandler(reader tilepack.MbtilesReader) gohttp.HandlerFunc {


### PR DESCRIPTION
* Allow for alternative prefixes in tile-matching regular expression in `http/mbtiles.go`
* Trim `bboxStr` in `cmd/build` so that ", " -separated bounding box strings work