### PR TITLE
Add optional flag to disable gzip encoding; More liberal tile URL regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Usage of ./bin/build:
     	Enables CPU profiling. Saves the dump to the given path.
   -dsn string
     	Path, or DSN string, to output files.
+  -ensure-gzip
+    	Ensure tile data is gzipped. Only applies to XYZ tiles. (default true)
   -file-transport-root string
     	The root directory for tiles if -url-template defines a file:// URL scheme
   -generator string

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -87,6 +87,7 @@ func main() {
 
 	boundingBoxFloats := make([]float64, 4)
 	for i, bboxStr := range boundingBoxStrSplit {
+		bboxStr = strings.TrimSpace(bboxStr)
 		bboxFloat, err := strconv.ParseFloat(bboxStr, 64)
 		if err != nil {
 			log.Fatalf("Bounding box string could not be parsed as numbers")

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -57,6 +57,7 @@ func main() {
 	requestTimeout := flag.Int("timeout", 60, "HTTP client timeout for tile requests.")
 	cpuProfile := flag.String("cpuprofile", "", "Enables CPU profiling. Saves the dump to the given path.")
 	invertedY := flag.Bool("inverted-y", false, "Invert the Y-value of tiles to match the TMS (as opposed to ZXY) tile format.")
+	ensureGzip := flag.Bool("ensure-gzip", true, "Ensure tile data is gzipped. Only applies to XYZ tiles.")
 	urlTemplateStr := flag.String("url-template", "", "(For xyz generator) URL template to make tile requests with. If URL template begins with file:// you must pass the -file-transport-root flag.")
 	layerNameStr := flag.String("layer-name", "", "(For metatile, tapalcatl2 generator) The layer name to use for hash building.")
 	pathTemplateStr := flag.String("path-template", "", "(For metatile, tapalcatl2 generator) The template to use for the path part of the S3 path to the t2 archive.")
@@ -165,9 +166,9 @@ func main() {
 				log.Fatalf("-file-transport-root flag is required when URL template uses file://")
 			}
 
-			jobCreator, err = tilepack.NewFileTransportXYZJobGenerator(*fileTransportRoot, *urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY)
+			jobCreator, err = tilepack.NewFileTransportXYZJobGenerator(*fileTransportRoot, *urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY, *ensureGzip)
 		} else {
-			jobCreator, err = tilepack.NewXYZJobGenerator(*urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY)
+			jobCreator, err = tilepack.NewXYZJobGenerator(*urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY, *ensureGzip)
 		}
 
 	case "metatile":

--- a/http/mbtiles.go
+++ b/http/mbtiles.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	tilezenRegex = regexp.MustCompile(`^\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
+	tilezenRegex = regexp.MustCompile(`\/tilezen\/vector\/v1\/512\/all\/(\d+)\/(\d+)\/(\d+)\.mvt$`)
 )
 
 func MbtilesHandler(reader tilepack.MbtilesReader) gohttp.HandlerFunc {

--- a/tilepack/http_job_creator.go
+++ b/tilepack/http_job_creator.go
@@ -1,11 +1,11 @@
 package tilepack
 
 import (
-	"bytes"
-	"compress/gzip"
+	_ "bytes"
+	_ "compress/gzip"
 	"errors"
 	"fmt"
-	"io"
+	_ "io"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -125,8 +125,8 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 	f := func(id int, jobs chan *TileRequest, results chan *TileResponse) {
 
 		// Instantiate the gzip support stuff once instead on every iteration
-		bodyBuffer := bytes.NewBuffer(nil)
-		bodyGzipper := gzip.NewWriter(bodyBuffer)
+		// bodyBuffer := bytes.NewBuffer(nil)
+		// bodyGzipper := gzip.NewWriter(bodyBuffer)
 
 		for request := range jobs {
 			start := time.Now()
@@ -154,6 +154,10 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 				// If the server reports content encoding of gzip, we can just copy the bytes as-is
 				bodyData, err = ioutil.ReadAll(resp.Body)
 			default:
+
+				bodyData, err = ioutil.ReadAll(resp.Body)
+
+				/*
 				// Otherwise we'll gzip the data, so we should
 				// reset at the top in case we ran into a continue below
 				bodyBuffer.Reset()
@@ -172,6 +176,7 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 				}
 
 				bodyData, err = ioutil.ReadAll(bodyBuffer)
+			*/
 				if err != nil {
 					log.Printf("Couldn't read bytes into byte array: %+v", err)
 					continue

--- a/tilepack/http_job_creator.go
+++ b/tilepack/http_job_creator.go
@@ -1,11 +1,11 @@
 package tilepack
 
 import (
-	_ "bytes"
-	_ "compress/gzip"
+	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
-	_ "io"
+	"io"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -32,7 +32,7 @@ const (
 	httpUserAgent = "go-tilepacks/1.0"
 )
 
-func NewXYZJobGenerator(urlTemplate string, bounds *LngLatBbox, zooms []uint, httpTimeout time.Duration, invertedY bool) (JobGenerator, error) {
+func NewXYZJobGenerator(urlTemplate string, bounds *LngLatBbox, zooms []uint, httpTimeout time.Duration, invertedY bool, ensureGzip bool) (JobGenerator, error) {
 	// Configure the HTTP client with a timeout and connection pools
 	httpClient := &http.Client{}
 	httpClient.Timeout = httpTimeout
@@ -48,10 +48,11 @@ func NewXYZJobGenerator(urlTemplate string, bounds *LngLatBbox, zooms []uint, ht
 		bounds:      bounds,
 		zooms:       zooms,
 		invertedY:   invertedY,
+		ensureGzip:  ensureGzip,
 	}, nil
 }
 
-func NewFileTransportXYZJobGenerator(root string, urlTemplate string, bounds *LngLatBbox, zooms []uint, httpTimeout time.Duration, invertedY bool) (JobGenerator, error) {
+func NewFileTransportXYZJobGenerator(root string, urlTemplate string, bounds *LngLatBbox, zooms []uint, httpTimeout time.Duration, invertedY bool, ensureGzip bool) (JobGenerator, error) {
 
 	info, err := os.Stat(root)
 
@@ -76,6 +77,7 @@ func NewFileTransportXYZJobGenerator(root string, urlTemplate string, bounds *Ln
 		bounds:      bounds,
 		zooms:       zooms,
 		invertedY:   invertedY,
+		ensureGzip:  ensureGzip,
 	}, nil
 }
 
@@ -85,6 +87,7 @@ type xyzJobGenerator struct {
 	bounds      *LngLatBbox
 	zooms       []uint
 	invertedY   bool
+	ensureGzip  bool
 }
 
 func doHTTPWithRetry(client *http.Client, request *http.Request, nRetries int) (*http.Response, error) {
@@ -125,8 +128,8 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 	f := func(id int, jobs chan *TileRequest, results chan *TileResponse) {
 
 		// Instantiate the gzip support stuff once instead on every iteration
-		// bodyBuffer := bytes.NewBuffer(nil)
-		// bodyGzipper := gzip.NewWriter(bodyBuffer)
+		bodyBuffer := bytes.NewBuffer(nil)
+		bodyGzipper := gzip.NewWriter(bodyBuffer)
 
 		for request := range jobs {
 			start := time.Now()
@@ -155,28 +158,30 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 				bodyData, err = ioutil.ReadAll(resp.Body)
 			default:
 
-				bodyData, err = ioutil.ReadAll(resp.Body)
+				if !x.ensureGzip {
+					bodyData, err = ioutil.ReadAll(resp.Body)
+				} else {
 
-				/*
-				// Otherwise we'll gzip the data, so we should
-				// reset at the top in case we ran into a continue below
-				bodyBuffer.Reset()
-				bodyGzipper.Reset(bodyBuffer)
+					// Otherwise we'll gzip the data, so we should
+					// reset at the top in case we ran into a continue below
+					bodyBuffer.Reset()
+					bodyGzipper.Reset(bodyBuffer)
 
-				_, err = io.Copy(bodyGzipper, resp.Body)
-				if err != nil {
-					log.Printf("Couldn't copy to gzipper: %+v", err)
-					continue
+					_, err = io.Copy(bodyGzipper, resp.Body)
+					if err != nil {
+						log.Printf("Couldn't copy to gzipper: %+v", err)
+						continue
+					}
+
+					err = bodyGzipper.Flush()
+					if err != nil {
+						log.Printf("Couldn't flush gzipper: %+v", err)
+						continue
+					}
+
+					bodyData, err = ioutil.ReadAll(bodyBuffer)
 				}
 
-				err = bodyGzipper.Flush()
-				if err != nil {
-					log.Printf("Couldn't flush gzipper: %+v", err)
-					continue
-				}
-
-				bodyData, err = ioutil.ReadAll(bodyBuffer)
-			*/
 				if err != nil {
 					log.Printf("Couldn't read bytes into byte array: %+v", err)
 					continue


### PR DESCRIPTION
This PR:

* Adds a `-ensure-gzip` flag for XYZ workers to `cmd/build`. It defaults to true which preserves existing behaviour but can be disabled to store raw bytes (in `tilepack/http_job_creator.go`) 

* Updates the `tilezenRegex` pattern to ensure that `tilezen/...` is present but removes the requirement that it must be the prefix.

* Trims whitespace from bounding box strings