### PR TITLE
Don't do deltaZ check

### DIFF
--- a/tilepack/metatile_job_creator.go
+++ b/tilepack/metatile_job_creator.go
@@ -70,10 +70,6 @@ type metatileJobGenerator struct {
 }
 
 func (x *metatileJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, results chan *TileResponse), error) {
-	metaZoom := maptile.Zoom(log2Uint(x.metatileSize))
-	tileZoom := maptile.Zoom(log2Uint(tileScale))
-	deltaZoom := metaZoom - tileZoom
-
 	f := func(id int, jobs chan *TileRequest, results chan *TileResponse) {
 		// Instantiate the gzip support stuff once instead on every iteration
 		bodyBuffer := bytes.NewBuffer(nil)
@@ -119,12 +115,6 @@ func (x *metatileJobGenerator) CreateWorker() (func(id int, jobs chan *TileReque
 					(metaTileRequest.Tile.Y<<offsetZ)+offsetY,
 					metaTileRequest.Tile.Z+maptile.Zoom(offsetZ),
 				)
-
-				// Only extract the zoom out of the metatile corresponding with the tile scale we care about.
-				// The 0/0/0.zip metatile is special cased so we can get to the top of the pyramid.
-				if metaTileRequest.Tile.Z != 0 && offsetZ != uint32(deltaZoom) {
-					continue
-				}
 
 				if !arrayContains(t.Z, x.zooms) {
 					continue


### PR DESCRIPTION
Removing this deltaZ check, since it prevented getting all the way to zoom 16 on the metatile fetching.