### PR TITLE
Use goreleaser-cross container img for gh release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -11,20 +10,20 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+
+    container:
+      image: docker.io/goreleaser/goreleaser-cross:v1.23
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: '~> v2'
-          args: release --clean
+      - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Required because of https://github.com/actions/checkout/issues/766
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          goreleaser release


### PR DESCRIPTION
- Following on from https://github.com/tilezen/go-tilepacks/pull/30
- This time the workflow has been verified to work on my fork: https://github.com/spwoodcock/go-tilepacks/actions/runs/11942875622/job/33290792326
  - See the final release and binaries here: https://github.com/spwoodcock/go-tilepacks/releases/tag/0.1.0
- I was a bit hasty ready the failed workflow logs: https://github.com/tilezen/go-tilepacks/actions/runs/11872649486/job/33086593280 and commenting on the PR. The issue isn't to do with Android at all. It's missing `gcc` and `gcc` binaries for most platforms...
- The solution was to move away from the typical Goreleaser Github action & instead use the `goreleaser-cross` image manually.
- The container image contains all required dependencies for cross compiling, making it really simple.

Note: I also updated the workflow to run only on **release**, as goreleaser needs a release to attach the built binaries to.