### PR TITLE
Decompress gzipped tile responses automatically if `mbtiles-format` is not PBF 

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -155,7 +155,7 @@ func main() {
 
 			jobCreator, err = tilepack.NewFileTransportXYZJobGenerator(*fileTransportRoot, *urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY, *ensureGzip)
 		} else {
-			jobCreator, err = tilepack.NewXYZJobGenerator(*urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY, *ensureGzip)
+			jobCreator, err = tilepack.NewXYZJobGenerator(*urlTemplateStr, bounds, zooms, time.Duration(*requestTimeout)*time.Second, *invertedY, *ensureGzip, *mbtilesFormat)
 		}
 
 	case "metatile":


### PR DESCRIPTION
Fixes #37

Required for raster type MBTiles.