### PR TITLE
Update to Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.23"
+        go-version: "1.26"
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: docker.io/goreleaser/goreleaser-cross:v1.23
+      image: docker.io/goreleaser/goreleaser-cross:v1.26.3
 
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tilezen/go-tilepacks
 
-go 1.23
+go 1.26
 
 require (
 	github.com/aaronland/go-string v1.0.0


### PR DESCRIPTION
## Summary

- Bump `go.mod` minimum Go version from 1.23 to 1.26
- Update CI workflow (`go.yml`) to build/test with Go 1.26
- Update release workflow to use `goreleaser-cross:v1.26.3` (latest)