### PR TITLE
Add test coverage for tilepack and http packages

### DIFF
--- a/cmd/build/build_test.go
+++ b/cmd/build/build_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+	"github.com/schollz/progressbar/v3"
+	"github.com/tilezen/go-tilepacks/tilepack"
+)
+
+// stubOutputter records Save calls so processResults tests can verify behavior
+// without writing to disk or a real database.
+type stubOutputter struct {
+	saved []savedTile
+}
+
+type savedTile struct {
+	tile maptile.Tile
+	data []byte
+}
+
+func (s *stubOutputter) CreateTiles() error { return nil }
+func (s *stubOutputter) Close() error       { return nil }
+func (s *stubOutputter) AssignSpatialMetadata(_ orb.Bound, _, _ maptile.Zoom) error {
+	return nil
+}
+func (s *stubOutputter) Save(tile maptile.Tile, data []byte) error {
+	s.saved = append(s.saved, savedTile{tile, data})
+	return nil
+}
+
+func TestProcessResults(t *testing.T) {
+	// processResults must call Save on the outputter for every TileResponse
+	// received before the results channel is closed, and must not skip tiles.
+	out := &stubOutputter{}
+	results := make(chan *tilepack.TileResponse, 3)
+
+	results <- &tilepack.TileResponse{Tile: maptile.New(0, 0, 0), Data: []byte("a")}
+	results <- &tilepack.TileResponse{Tile: maptile.New(1, 0, 1), Data: []byte("b")}
+	close(results)
+
+	bar := progressbar.NewOptions(2, progressbar.OptionSetWriter(io.Discard))
+	processResults(results, out, bar)
+
+	if len(out.saved) != 2 {
+		t.Errorf("expected 2 saved tiles, got %d", len(out.saved))
+	}
+}

--- a/cmd/merge/merge_test.go
+++ b/cmd/merge/merge_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPathExists_Exists(t *testing.T) {
+	// pathExists must return true for a path that exists on disk (file or dir).
+	f, err := os.CreateTemp(t.TempDir(), "exists")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if !pathExists(f.Name()) {
+		t.Errorf("expected pathExists=true for existing file %s", f.Name())
+	}
+}
+
+func TestPathExists_NotExists(t *testing.T) {
+	// pathExists must return false for a path that does not exist, preventing
+	// the merge command from accidentally overwriting an absent output file.
+	if pathExists("/this/path/does/not/exist/hopefully") {
+		t.Error("expected pathExists=false for nonexistent path")
+	}
+}

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggingMiddleware(t *testing.T) {
+	// loggingMiddleware must pass the request to the next handler and write a
+	// log line containing the request path, method, and remote address.
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	handler := loggingMiddleware(logger)(inner)
+
+	req := httptest.NewRequest("GET", "/tilepath", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("/tilepath")) {
+		t.Errorf("expected log entry to contain '/tilepath', got: %s", logBuf.String())
+	}
+}
+
+func TestDefaultHandler(t *testing.T) {
+	// defaultHandler must return 404 for any request — it is the fallback
+	// route for paths that don't match the tile or preview endpoints.
+	req := httptest.NewRequest("GET", "/unrecognized", nil)
+	rr := httptest.NewRecorder()
+	defaultHandler(rr, req)
+	if rr.Code != 404 {
+		t.Errorf("expected 404, got %d", rr.Code)
+	}
+}

--- a/http/mbtiles_test.go
+++ b/http/mbtiles_test.go
@@ -1,0 +1,160 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/paulmach/orb/maptile"
+	"github.com/tilezen/go-tilepacks/tilepack"
+)
+
+// stubReader is a minimal MbtilesReader that returns canned responses for
+// testing the HTTP handler without a real SQLite database.
+type stubReader struct {
+	data map[maptile.Tile][]byte
+}
+
+func (s *stubReader) Close() error { return nil }
+
+func (s *stubReader) GetTile(tile maptile.Tile) (*tilepack.TileData, error) {
+	d, ok := s.data[tile]
+	if !ok {
+		return &tilepack.TileData{Tile: tile, Data: nil}, nil
+	}
+	return &tilepack.TileData{Tile: tile, Data: &d}, nil
+}
+
+func (s *stubReader) VisitAllTiles(visitor func(maptile.Tile, []byte)) error { return nil }
+
+func (s *stubReader) Metadata() (*tilepack.MbtilesMetadata, error) {
+	return tilepack.NewMbtilesMetadata(map[string]string{}), nil
+}
+
+// TestParseTileFromPath verifies that the Tilezen URL pattern is parsed into
+// the correct (z, x, y) tile coordinates.
+func TestParseTileFromPath(t *testing.T) {
+	cases := []struct {
+		path    string
+		z, x, y uint32
+		wantErr bool
+	}{
+		{
+			// Standard tile path must parse correctly.
+			path: "/tilezen/vector/v1/512/all/5/10/12.mvt",
+			z: 5, x: 10, y: 12,
+		},
+		{
+			// Zoom 0, tile 0/0 is a valid degenerate case.
+			path: "/tilezen/vector/v1/512/all/0/0/0.mvt",
+			z: 0, x: 0, y: 0,
+		},
+		{
+			// A path that doesn't match the pattern must return an error so the
+			// handler can respond with 404 rather than a panic or zero tile.
+			path:    "/not/a/tile/path",
+			wantErr: true,
+		},
+		{
+			// Missing the .mvt extension must not match.
+			path:    "/tilezen/vector/v1/512/all/5/10/12",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			tile, err := parseTileFromPath(tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for path %q, got nil", tc.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for path %q: %v", tc.path, err)
+			}
+			if uint32(tile.Z) != tc.z || tile.X != tc.x || tile.Y != tc.y {
+				t.Errorf("path %q: got z=%d x=%d y=%d, want z=%d x=%d y=%d",
+					tc.path, tile.Z, tile.X, tile.Y, tc.z, tc.x, tc.y)
+			}
+		})
+	}
+}
+
+// TestMbtilesHandler_TileFound verifies that the handler returns the tile bytes
+// with the correct Content-Type when the tile exists in the reader.
+func TestMbtilesHandler_TileFound(t *testing.T) {
+	tile := maptile.New(10, 12, 5)
+	tileData := []byte("protobuf-tile-data")
+
+	reader := &stubReader{data: map[maptile.Tile][]byte{tile: tileData}}
+	handler := MbtilesHandler(reader)
+
+	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/5/10/12.mvt", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/x-protobuf" {
+		t.Errorf("expected Content-Type application/x-protobuf, got %q", ct)
+	}
+	if body := rr.Body.String(); body != string(tileData) {
+		t.Errorf("unexpected body: %q", body)
+	}
+}
+
+// TestMbtilesHandler_TileNotFound verifies that the handler returns 404 when
+// the tile exists in the URL but is absent from the backing store.
+func TestMbtilesHandler_TileNotFound(t *testing.T) {
+	reader := &stubReader{data: map[maptile.Tile][]byte{}}
+	handler := MbtilesHandler(reader)
+
+	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/5/10/12.mvt", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rr.Code)
+	}
+}
+
+// TestMbtilesHandler_InvalidPath verifies that an unrecognized URL path gets a
+// 404 rather than a 500 or panic.
+func TestMbtilesHandler_InvalidPath(t *testing.T) {
+	reader := &stubReader{data: map[maptile.Tile][]byte{}}
+	handler := MbtilesHandler(reader)
+
+	req := httptest.NewRequest(http.MethodGet, "/not/a/tile", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rr.Code)
+	}
+}
+
+// TestMbtilesHandler_GzipHeader verifies that the Content-Encoding: gzip
+// header is set when the client signals it accepts gzip-encoded responses.
+// (Tiles in an MBTiles file are stored gzip-compressed and sent as-is.)
+func TestMbtilesHandler_GzipHeader(t *testing.T) {
+	tile := maptile.New(0, 0, 0)
+	reader := &stubReader{data: map[maptile.Tile][]byte{tile: []byte("data")}}
+	handler := MbtilesHandler(reader)
+
+	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/0/0/0.mvt", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if ce := rr.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("expected Content-Encoding: gzip, got %q", ce)
+	}
+}

--- a/http/mbtiles_test.go
+++ b/http/mbtiles_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,6 +30,54 @@ func (s *stubReader) VisitAllTiles(visitor func(maptile.Tile, []byte)) error { r
 
 func (s *stubReader) Metadata() (*tilepack.MbtilesMetadata, error) {
 	return tilepack.NewMbtilesMetadata(map[string]string{}), nil
+}
+
+// errorReader is a stubReader variant whose GetTile always returns an error,
+// used to test the handler's error branch.
+type errorReader struct{}
+
+func (e *errorReader) Close() error { return nil }
+func (e *errorReader) GetTile(_ maptile.Tile) (*tilepack.TileData, error) {
+	return nil, fmt.Errorf("simulated read error")
+}
+func (e *errorReader) VisitAllTiles(_ func(maptile.Tile, []byte)) error { return nil }
+func (e *errorReader) Metadata() (*tilepack.MbtilesMetadata, error) {
+	return tilepack.NewMbtilesMetadata(map[string]string{}), nil
+}
+
+// TestMbtilesHandler_NoGzipAccept verifies that when a client does not send
+// Accept-Encoding: gzip, the tile is still served (without the Content-Encoding
+// header) and the log.Printf warning branch in the handler is exercised.
+func TestMbtilesHandler_NoGzipAccept(t *testing.T) {
+	tile := maptile.New(0, 0, 0)
+	reader := &stubReader{data: map[maptile.Tile][]byte{tile: []byte("data")}}
+	handler := MbtilesHandler(reader)
+
+	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/0/0/0.mvt", nil)
+	// No Accept-Encoding header set — triggers the warning log path.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if ce := rr.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("expected no Content-Encoding header, got %q", ce)
+	}
+}
+
+// TestMbtilesHandler_GetTileError verifies that the handler returns 404 when
+// the backing reader returns an error (e.g. database corruption or I/O failure).
+func TestMbtilesHandler_GetTileError(t *testing.T) {
+	handler := MbtilesHandler(&errorReader{})
+
+	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/0/0/0.mvt", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 on reader error, got %d", rr.Code)
+	}
 }
 
 // TestParseTileFromPath verifies that the Tilezen URL pattern is parsed into

--- a/http/mbtiles_test.go
+++ b/http/mbtiles_test.go
@@ -1,7 +1,10 @@
 package http
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -189,12 +192,26 @@ func TestMbtilesHandler_InvalidPath(t *testing.T) {
 	}
 }
 
-// TestMbtilesHandler_GzipHeader verifies that the Content-Encoding: gzip
-// header is set when the client signals it accepts gzip-encoded responses.
-// (Tiles in an MBTiles file are stored gzip-compressed and sent as-is.)
+// gzipData compresses b and returns the compressed bytes.
+func gzipData(b []byte) []byte {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	w.Write(b)
+	w.Close()
+	return buf.Bytes()
+}
+
+// TestMbtilesHandler_GzipHeader verifies that:
+//   - Content-Encoding: gzip is set when the client accepts gzip
+//   - The response body is the exact gzip bytes stored in the reader (tiles are
+//     stored pre-compressed and must be passed through unmodified)
 func TestMbtilesHandler_GzipHeader(t *testing.T) {
 	tile := maptile.New(0, 0, 0)
-	reader := &stubReader{data: map[maptile.Tile][]byte{tile: []byte("data")}}
+	// Store actually-compressed bytes so we can verify passthrough integrity.
+	originalData := []byte("real-tile-data")
+	compressed := gzipData(originalData)
+
+	reader := &stubReader{data: map[maptile.Tile][]byte{tile: compressed}}
 	handler := MbtilesHandler(reader)
 
 	req := httptest.NewRequest(http.MethodGet, "/tilezen/vector/v1/512/all/0/0/0.mvt", nil)
@@ -205,5 +222,18 @@ func TestMbtilesHandler_GzipHeader(t *testing.T) {
 
 	if ce := rr.Header().Get("Content-Encoding"); ce != "gzip" {
 		t.Errorf("expected Content-Encoding: gzip, got %q", ce)
+	}
+
+	// The body must be valid gzip that decompresses to the original data.
+	gr, err := gzip.NewReader(rr.Body)
+	if err != nil {
+		t.Fatalf("response body is not valid gzip: %v", err)
+	}
+	got, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("decompressing response: %v", err)
+	}
+	if !bytes.Equal(got, originalData) {
+		t.Errorf("decompressed body mismatch: got %q, want %q", got, originalData)
 	}
 }

--- a/tilepack/disk_outputter_test.go
+++ b/tilepack/disk_outputter_test.go
@@ -1,0 +1,169 @@
+package tilepack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+)
+
+func TestNewDiskOutputter_MissingRequired(t *testing.T) {
+	// NewDiskOutputter must return an error when required DSN keys are absent.
+	// The 'root' key is required; an empty DSN string should fail.
+	_, err := NewDiskOutputter("")
+	if err == nil {
+		t.Fatal("expected error for empty DSN")
+	}
+}
+
+func TestDiskOutputter_Save_CreatesSubdirs(t *testing.T) {
+	// Save must create intermediate Z/X directories when they don't yet exist,
+	// not just fail because the parent dir is missing.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	// Save a tile at a zoom level that requires nested directories.
+	tile := maptile.New(15, 10, 5)
+	if err := o.Save(tile, []byte("data")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, "5/15/10.pbf")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected tile file at %s: %v", expectedPath, err)
+	}
+}
+
+func TestNewDiskOutputter_Valid(t *testing.T) {
+	// NewDiskOutputter must succeed for a valid DSN pointing at an existing directory.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o == nil {
+		t.Fatal("expected non-nil outputter")
+	}
+}
+
+func TestDiskOutputter_CreateTiles_CreatesDir(t *testing.T) {
+	// CreateTiles must create the root directory when it does not yet exist.
+	dir := filepath.Join(t.TempDir(), "tiles")
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("expected root directory to exist after CreateTiles: %v", err)
+	}
+}
+
+func TestDiskOutputter_CreateTiles_ExistingDir(t *testing.T) {
+	// CreateTiles must succeed (no error) when the root directory already exists.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles on existing dir: %v", err)
+	}
+}
+
+func TestDiskOutputter_CreateTiles_RootIsFile(t *testing.T) {
+	// CreateTiles must return an error when the root path exists but is a file,
+	// not a directory — writing Z/X/Y tiles inside a file is impossible.
+	f, err := os.CreateTemp(t.TempDir(), "notadir")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	f.Close()
+
+	o, err := NewDiskOutputter("root=" + f.Name() + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err == nil {
+		t.Fatal("expected error when root is a file, got nil")
+	}
+}
+
+func TestDiskOutputter_CreateTiles_Idempotent(t *testing.T) {
+	// Calling CreateTiles twice must succeed; the second call is a no-op.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("first CreateTiles: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("second CreateTiles: %v", err)
+	}
+}
+
+func TestDiskOutputter_Save(t *testing.T) {
+	// Save must write tile data to the correct Z/X/Y.format path under the root.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	tile := maptile.New(3, 2, 5)
+	data := []byte("tile-bytes")
+	if err := o.Save(tile, data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, "5/3/2.pbf")
+	got, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("expected file at %s: %v", expectedPath, err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("file content mismatch: got %q, want %q", got, data)
+	}
+}
+
+func TestDiskOutputter_AssignSpatialMetadata(t *testing.T) {
+	// AssignSpatialMetadata is a no-op for disk output (metadata is not stored
+	// in a flat-file tile tree), but must not return an error.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	bounds := orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}}
+	if err := o.AssignSpatialMetadata(bounds, 0, 5); err != nil {
+		t.Fatalf("AssignSpatialMetadata: %v", err)
+	}
+}
+
+func TestDiskOutputter_Close(t *testing.T) {
+	// Close is a no-op for disk output (no connection to tear down), but must
+	// not return an error.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}

--- a/tilepack/http_job_creator.go
+++ b/tilepack/http_job_creator.go
@@ -128,7 +128,7 @@ func doHTTPWithRetry(client *http.Client, request *http.Request, nRetries int) (
 
 		time.Sleep(sleep)
 		sleep *= 2.0
-		if sleep > 30.0 {
+		if sleep > 30*time.Second {
 			sleep = 30 * time.Second
 		}
 	}

--- a/tilepack/http_job_creator_test.go
+++ b/tilepack/http_job_creator_test.go
@@ -1,0 +1,342 @@
+package tilepack
+
+import (
+	"compress/gzip"
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+)
+
+// gzipBytes compresses b and returns the compressed form.
+func gzipBytes(b []byte) []byte {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	w.Write(b)
+	w.Close()
+	return buf.Bytes()
+}
+
+func TestHTTPError_ErrorAndString(t *testing.T) {
+	// HTTPError must implement the error interface and return a human-readable status.
+	e := &HTTPError{Code: 404, Status: "404 Not Found"}
+	if e.Error() != "404 Not Found" {
+		t.Errorf("Error(): got %q", e.Error())
+	}
+	if e.String() != "404 Not Found" {
+		t.Errorf("String(): got %q", e.String())
+	}
+}
+
+func TestDoHTTPWithRetry_Success(t *testing.T) {
+	// A 200 response must be returned immediately without retrying.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	resp, err := doHTTPWithRetry(srv.Client(), req, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestDoHTTPWithRetry_ClientError_NoRetry(t *testing.T) {
+	// 4xx responses are not retried — they are returned immediately as HTTPError
+	// because retrying a client error will never succeed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	_, err := doHTTPWithRetry(srv.Client(), req, 3)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	var httpErr *HTTPError
+	if httpErr, ok := err.(*HTTPError); !ok || httpErr.Code != 404 {
+		t.Errorf("expected HTTPError with code 404, got %T %v", err, err)
+	}
+	_ = httpErr
+}
+
+func TestDoHTTPWithRetry_ServerError_ExhaustsRetries(t *testing.T) {
+	// 5xx responses are retried. When all retries are exhausted an error is returned.
+	// NOTE: the production sleep cap has a bug (compares time.Duration to 30.0ns
+	// instead of 30s), so each retry sleeps 30s. We use nRetries=0 here to test
+	// the exhaustion path without actually sleeping.
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(503)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	_, err := doHTTPWithRetry(client, req, 0)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// With nRetries=0 the loop body never executes, so the server is never called.
+	if callCount != 0 {
+		t.Errorf("expected 0 server calls with nRetries=0, got %d", callCount)
+	}
+}
+
+func TestNewFileTransportXYZJobGenerator_BadRoot(t *testing.T) {
+	// NewFileTransportXYZJobGenerator must return an error if the root path
+	// does not exist, preventing silent misconfiguration.
+	_, err := NewFileTransportXYZJobGenerator(
+		"/nonexistent/path",
+		"file://{z}/{x}/{y}.pbf",
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		[]maptile.Zoom{0},
+		5*time.Second,
+		false,
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected error for non-existent root directory")
+	}
+}
+
+func TestNewFileTransportXYZJobGenerator_RootIsFile(t *testing.T) {
+	// NewFileTransportXYZJobGenerator must return an error when root is a file
+	// rather than a directory.
+	f, _ := os.CreateTemp(t.TempDir(), "notadir")
+	f.Close()
+
+	_, err := NewFileTransportXYZJobGenerator(
+		f.Name(),
+		"file://{z}/{x}/{y}.pbf",
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		[]maptile.Zoom{0},
+		5*time.Second,
+		false,
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected error when root is a file")
+	}
+}
+
+func TestXYZJobGenerator_CreateJobs_URLTemplate(t *testing.T) {
+	// CreateJobs must expand {z}, {x}, {y} placeholders in the URL template
+	// and send one TileRequest per tile in the bounds.
+	gen, err := NewXYZJobGenerator(
+		"https://example.com/tiles/{z}/{x}/{y}.pbf",
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		[]maptile.Zoom{0},
+		5*time.Second,
+		false,
+		false,
+		"pbf",
+	)
+	if err != nil {
+		t.Fatalf("NewXYZJobGenerator: %v", err)
+	}
+
+	jobs := make(chan *TileRequest, 10)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	var reqs []*TileRequest
+	for r := range jobs {
+		reqs = append(reqs, r)
+	}
+
+	// At z=0 there is exactly one tile.
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(reqs))
+	}
+	expected := "https://example.com/tiles/0/0/0.pbf"
+	if reqs[0].URL != expected {
+		t.Errorf("expected URL %q, got %q", expected, reqs[0].URL)
+	}
+}
+
+func TestXYZJobGenerator_CreateJobs_InvertedY(t *testing.T) {
+	// When invertedY=true, tile Y values in the jobs must use TMS numbering.
+	// At z=1 the southwest quadrant in TMS has Y=0; in XYZ it has Y=1.
+	gen, err := NewXYZJobGenerator(
+		"{z}/{x}/{y}",
+		// Strictly south of equator so only the bottom row of tiles is included.
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{-90, -1}},
+		[]maptile.Zoom{1},
+		5*time.Second,
+		true,  // invertedY
+		false,
+		"pbf",
+	)
+	if err != nil {
+		t.Fatalf("NewXYZJobGenerator: %v", err)
+	}
+
+	jobs := make(chan *TileRequest, 10)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	for r := range jobs {
+		if r.Tile.Y != 0 {
+			t.Errorf("invertedY=true: expected TMS Y=0 for south tile, got Y=%d in URL %s", r.Tile.Y, r.URL)
+		}
+	}
+}
+
+// writeTileToServer serves tile data from a directory using an HTTP test server
+// so CreateWorker can fetch it via http://.
+func setupTileServer(t *testing.T, path string, data []byte, contentEncoding string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentEncoding != "" {
+			w.Header().Set("Content-Encoding", contentEncoding)
+		}
+		w.WriteHeader(200)
+		w.Write(data)
+	}))
+}
+
+func runWorker(t *testing.T, gen JobGenerator, tileURL string, tile maptile.Tile) *TileResponse {
+	t.Helper()
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 1)
+
+	worker, err := gen.CreateWorker()
+	if err != nil {
+		t.Fatalf("CreateWorker: %v", err)
+	}
+
+	jobs <- &TileRequest{Tile: tile, URL: tileURL}
+	close(jobs)
+
+	go worker(0, jobs, results)
+
+	select {
+	case r := <-results:
+		return r
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worker result")
+		return nil
+	}
+}
+
+func TestXYZWorker_PlainResponse_EnsureGzip(t *testing.T) {
+	// When the server returns uncompressed data and ensureGzip=true, the worker
+	// must gzip the data before sending it to results.  The stored bytes must
+	// decompress to the original payload.
+	original := []byte("raw-tile-data")
+	srv := setupTileServer(t, "/0/0/0.pbf", original, "")
+	defer srv.Close()
+
+	gen, _ := NewXYZJobGenerator(srv.URL+"/{z}/{x}/{y}.pbf", orb.Bound{}, nil, 5*time.Second, false, true, "pbf")
+	resp := runWorker(t, gen, srv.URL+"/0/0/0.pbf", maptile.New(0, 0, 0))
+
+	// Decompress and verify the stored data matches the original.
+	r, err := gzip.NewReader(bytes.NewReader(resp.Data))
+	if err != nil {
+		t.Fatalf("result is not gzip-compressed: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	if buf.String() != string(original) {
+		t.Errorf("decompressed data mismatch: got %q, want %q", buf.String(), original)
+	}
+}
+
+func TestXYZWorker_PlainResponse_NoEnsureGzip(t *testing.T) {
+	// When ensureGzip=false, uncompressed server responses must be stored as-is.
+	original := []byte("raw-tile-data")
+	srv := setupTileServer(t, "/0/0/0.pbf", original, "")
+	defer srv.Close()
+
+	gen, _ := NewXYZJobGenerator(srv.URL+"/{z}/{x}/{y}.pbf", orb.Bound{}, nil, 5*time.Second, false, false, "pbf")
+	resp := runWorker(t, gen, srv.URL+"/0/0/0.pbf", maptile.New(0, 0, 0))
+
+	if string(resp.Data) != string(original) {
+		t.Errorf("expected raw data %q, got %q", original, resp.Data)
+	}
+}
+
+func TestXYZWorker_GzipResponse_PBF_KeptCompressed(t *testing.T) {
+	// When the server responds with Content-Encoding: gzip and the format is PBF,
+	// the worker must store the compressed bytes as-is (MBTiles stores PBF gzipped).
+	original := []byte("pbf-tile-data")
+	compressed := gzipBytes(original)
+	srv := setupTileServer(t, "/0/0/0.pbf", compressed, "gzip")
+	defer srv.Close()
+
+	gen, _ := NewXYZJobGenerator(srv.URL+"/{z}/{x}/{y}.pbf", orb.Bound{}, nil, 5*time.Second, false, true, "pbf")
+	resp := runWorker(t, gen, srv.URL+"/0/0/0.pbf", maptile.New(0, 0, 0))
+
+	// Stored bytes must still be compressed — they are identical to what the server sent.
+	if !bytes.Equal(resp.Data, compressed) {
+		t.Errorf("PBF: expected compressed bytes to be kept as-is")
+	}
+}
+
+func TestXYZWorker_GzipResponse_Raster_Decompressed(t *testing.T) {
+	// Regression for issue #37: when the server returns Content-Encoding: gzip
+	// for a raster format (e.g. png), the worker must decompress the data before
+	// storing it.  Storing compressed raster bytes produces invalid PNG/JPG files.
+	original := []byte("png-tile-data")
+	compressed := gzipBytes(original)
+	srv := setupTileServer(t, "/0/0/0.png", compressed, "gzip")
+	defer srv.Close()
+
+	gen, _ := NewXYZJobGenerator(srv.URL+"/{z}/{x}/{y}.png", orb.Bound{}, nil, 5*time.Second, false, false, "png")
+	resp := runWorker(t, gen, srv.URL+"/0/0/0.png", maptile.New(0, 0, 0))
+
+	// Stored bytes must be the raw, uncompressed tile data.
+	if string(resp.Data) != string(original) {
+		t.Errorf("raster: expected decompressed data %q, got %q", original, resp.Data)
+	}
+}
+
+func TestFileTransportXYZWorker_FetchesTile(t *testing.T) {
+	// NewFileTransportXYZJobGenerator must serve tiles from a local directory
+	// using the file:// transport, producing the expected tile data in results.
+	// The URL template uses file:/// with paths relative to the registered root.
+	dir := t.TempDir()
+	tileData := []byte("local-tile")
+
+	// Write a tile at {root}/0/0/0.pbf.
+	tilePath := filepath.Join(dir, "0", "0")
+	os.MkdirAll(tilePath, 0755)
+	os.WriteFile(filepath.Join(tilePath, "0.pbf"), tileData, 0644)
+
+	gen, err := NewFileTransportXYZJobGenerator(
+		dir,
+		"file:///{z}/{x}/{y}.pbf",
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		[]maptile.Zoom{0},
+		5*time.Second,
+		false,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("NewFileTransportXYZJobGenerator: %v", err)
+	}
+
+	resp := runWorker(t, gen, "file:///0/0/0.pbf", maptile.New(0, 0, 0))
+	if string(resp.Data) != string(tileData) {
+		t.Errorf("expected %q, got %q", tileData, resp.Data)
+	}
+}

--- a/tilepack/http_job_creator_test.go
+++ b/tilepack/http_job_creator_test.go
@@ -74,10 +74,9 @@ func TestDoHTTPWithRetry_ClientError_NoRetry(t *testing.T) {
 }
 
 func TestDoHTTPWithRetry_ServerError_ExhaustsRetries(t *testing.T) {
-	// 5xx responses are retried. When all retries are exhausted an error is returned.
-	// NOTE: the production sleep cap has a bug (compares time.Duration to 30.0ns
-	// instead of 30s), so each retry sleeps 30s. We use nRetries=0 here to test
-	// the exhaustion path without actually sleeping.
+	// 5xx responses are retried. When all retries are exhausted an HTTPError is returned.
+	// We use nRetries=1 so the server is called once, returns 503, and the function
+	// gives up after the single attempt.
 	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
@@ -87,13 +86,12 @@ func TestDoHTTPWithRetry_ServerError_ExhaustsRetries(t *testing.T) {
 
 	client := &http.Client{Timeout: 2 * time.Second}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
-	_, err := doHTTPWithRetry(client, req, 0)
+	_, err := doHTTPWithRetry(client, req, 1)
 	if err == nil {
 		t.Fatal("expected error after exhausting retries")
 	}
-	// With nRetries=0 the loop body never executes, so the server is never called.
-	if callCount != 0 {
-		t.Errorf("expected 0 server calls with nRetries=0, got %d", callCount)
+	if callCount != 1 {
+		t.Errorf("expected 1 server call with nRetries=1, got %d", callCount)
 	}
 }
 

--- a/tilepack/mbtiles_metadata_test.go
+++ b/tilepack/mbtiles_metadata_test.go
@@ -1,0 +1,187 @@
+package tilepack
+
+import (
+	"testing"
+)
+
+func TestMbtilesMetadata_Get_Exists(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"name": "my-tileset"})
+	v, ok := m.Get("name")
+	if !ok {
+		t.Fatal("expected key 'name' to exist")
+	}
+	if v != "my-tileset" {
+		t.Errorf("expected 'my-tileset', got %q", v)
+	}
+}
+
+func TestMbtilesMetadata_Get_Missing(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{})
+	_, ok := m.Get("missing")
+	if ok {
+		t.Fatal("expected missing key to return ok=false")
+	}
+}
+
+func TestMbtilesMetadata_Bounds_Valid(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{
+		"bounds": "-122.4,37.7,-122.3,37.8",
+	})
+	b, err := m.Bounds()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.Min[0] != -122.4 || b.Min[1] != 37.7 || b.Max[0] != -122.3 || b.Max[1] != 37.8 {
+		t.Errorf("unexpected bounds: %+v", b)
+	}
+}
+
+func TestMbtilesMetadata_Bounds_Missing(t *testing.T) {
+	// A missing 'bounds' key must return an error, not a zero value.
+	m := NewMbtilesMetadata(map[string]string{})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for missing bounds key")
+	}
+}
+
+func TestMbtilesMetadata_Bounds_WrongPartCount(t *testing.T) {
+	// A bounds string with fewer than 4 comma-separated fields is malformed.
+	m := NewMbtilesMetadata(map[string]string{"bounds": "-122.4,37.7"})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for malformed bounds")
+	}
+}
+
+func TestMbtilesMetadata_Bounds_NonNumeric(t *testing.T) {
+	// Non-numeric values in the bounds string must return a parse error.
+	m := NewMbtilesMetadata(map[string]string{"bounds": "west,south,east,north"})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for non-numeric bounds")
+	}
+}
+
+func TestMbtilesMetadata_Center_Valid(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"center": "-77.0,38.9,5"})
+	pt, z, err := m.Center()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pt[0] != -77.0 || pt[1] != 38.9 {
+		t.Errorf("unexpected center point: %+v", pt)
+	}
+	if z != 5 {
+		t.Errorf("expected zoom 5, got %d", z)
+	}
+}
+
+func TestMbtilesMetadata_Center_Missing(t *testing.T) {
+	// A missing 'center' key must return an error.
+	m := NewMbtilesMetadata(map[string]string{})
+	_, _, err := m.Center()
+	if err == nil {
+		t.Fatal("expected error for missing center key")
+	}
+}
+
+func TestMbtilesMetadata_Center_WrongPartCount(t *testing.T) {
+	// Center must have exactly 3 comma-separated fields: lon,lat,zoom.
+	m := NewMbtilesMetadata(map[string]string{"center": "-77.0,38.9"})
+	_, _, err := m.Center()
+	if err == nil {
+		t.Fatal("expected error for malformed center")
+	}
+}
+
+func TestMbtilesMetadata_MinZoom_Valid(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"minzoom": "2"})
+	z, err := m.MinZoom()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if z != 2 {
+		t.Errorf("expected minzoom 2, got %d", z)
+	}
+}
+
+func TestMbtilesMetadata_MinZoom_Missing(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{})
+	_, err := m.MinZoom()
+	if err == nil {
+		t.Fatal("expected error for missing minzoom")
+	}
+}
+
+func TestMbtilesMetadata_MinZoom_NonNumeric(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"minzoom": "two"})
+	_, err := m.MinZoom()
+	if err == nil {
+		t.Fatal("expected error for non-numeric minzoom")
+	}
+}
+
+func TestMbtilesMetadata_MaxZoom_Valid(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"maxzoom": "14"})
+	z, err := m.MaxZoom()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if z != 14 {
+		t.Errorf("expected maxzoom 14, got %d", z)
+	}
+}
+
+func TestMbtilesMetadata_MaxZoom_Missing(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{})
+	_, err := m.MaxZoom()
+	if err == nil {
+		t.Fatal("expected error for missing maxzoom")
+	}
+}
+
+func TestMbtilesMetadata_MaxZoom_NonNumeric(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"maxzoom": "fourteen"})
+	_, err := m.MaxZoom()
+	if err == nil {
+		t.Fatal("expected error for non-numeric maxzoom")
+	}
+}
+
+func TestMbtilesMetadata_Format(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"format": "pbf"})
+	f, err := m.Format()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f != "pbf" {
+		t.Errorf("expected format 'pbf', got %q", f)
+	}
+}
+
+func TestMbtilesMetadata_Name(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"name": "test-tiles"})
+	n, err := m.Name()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != "test-tiles" {
+		t.Errorf("expected name 'test-tiles', got %q", n)
+	}
+}
+
+func TestMbtilesMetadata_Set(t *testing.T) {
+	// Set must overwrite an existing key and create a new one.
+	m := NewMbtilesMetadata(map[string]string{"name": "old"})
+	m.Set("name", "new")
+	v, _ := m.Get("name")
+	if v != "new" {
+		t.Errorf("expected 'new', got %q", v)
+	}
+	m.Set("format", "mvt")
+	f, ok := m.Get("format")
+	if !ok || f != "mvt" {
+		t.Errorf("expected 'mvt', got %q (ok=%v)", f, ok)
+	}
+}

--- a/tilepack/mbtiles_metadata_test.go
+++ b/tilepack/mbtiles_metadata_test.go
@@ -183,6 +183,67 @@ func TestMbtilesMetadata_Name(t *testing.T) {
 	}
 }
 
+func TestMbtilesMetadata_Keys(t *testing.T) {
+	// Keys must return exactly the set of keys present in the metadata map.
+	m := NewMbtilesMetadata(map[string]string{"name": "x", "format": "pbf", "minzoom": "0"})
+	keys := m.Keys()
+	if len(keys) != 3 {
+		t.Errorf("expected 3 keys, got %d: %v", len(keys), keys)
+	}
+}
+
+func TestMbtilesMetadata_Bounds_NonNumeric_Miny(t *testing.T) {
+	// Each of the four bounds fields must individually fail on non-numeric input.
+	m := NewMbtilesMetadata(map[string]string{"bounds": "-122.4,bad,-122.3,37.8"})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for non-numeric miny")
+	}
+}
+
+func TestMbtilesMetadata_Bounds_NonNumeric_Maxx(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"bounds": "-122.4,37.7,bad,37.8"})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for non-numeric maxx")
+	}
+}
+
+func TestMbtilesMetadata_Bounds_NonNumeric_Maxy(t *testing.T) {
+	m := NewMbtilesMetadata(map[string]string{"bounds": "-122.4,37.7,-122.3,bad"})
+	_, err := m.Bounds()
+	if err == nil {
+		t.Fatal("expected error for non-numeric maxy")
+	}
+}
+
+func TestMbtilesMetadata_Center_NonNumeric_X(t *testing.T) {
+	// A non-numeric longitude in the center string must return a parse error.
+	m := NewMbtilesMetadata(map[string]string{"center": "bad,38.9,5"})
+	_, _, err := m.Center()
+	if err == nil {
+		t.Fatal("expected error for non-numeric center x")
+	}
+}
+
+func TestMbtilesMetadata_Center_NonNumeric_Y(t *testing.T) {
+	// A non-numeric latitude in the center string must return a parse error.
+	m := NewMbtilesMetadata(map[string]string{"center": "-77.0,bad,5"})
+	_, _, err := m.Center()
+	if err == nil {
+		t.Fatal("expected error for non-numeric center y")
+	}
+}
+
+func TestMbtilesMetadata_Center_NonNumeric_Zoom(t *testing.T) {
+	// A non-numeric zoom in the center string must return a parse error.
+	m := NewMbtilesMetadata(map[string]string{"center": "-77.0,38.9,five"})
+	_, _, err := m.Center()
+	if err == nil {
+		t.Fatal("expected error for non-numeric center zoom")
+	}
+}
+
 func TestMbtilesMetadata_Set(t *testing.T) {
 	// Set must overwrite an existing key and create a new one.
 	m := NewMbtilesMetadata(map[string]string{"name": "old"})

--- a/tilepack/mbtiles_metadata_test.go
+++ b/tilepack/mbtiles_metadata_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestMbtilesMetadata_Get_Exists(t *testing.T) {
+	// Get must return the value and ok=true for a key that was set.
 	m := NewMbtilesMetadata(map[string]string{"name": "my-tileset"})
 	v, ok := m.Get("name")
 	if !ok {
@@ -16,6 +17,7 @@ func TestMbtilesMetadata_Get_Exists(t *testing.T) {
 }
 
 func TestMbtilesMetadata_Get_Missing(t *testing.T) {
+	// Get must return ok=false for a key that was never set.
 	m := NewMbtilesMetadata(map[string]string{})
 	_, ok := m.Get("missing")
 	if ok {
@@ -24,6 +26,7 @@ func TestMbtilesMetadata_Get_Missing(t *testing.T) {
 }
 
 func TestMbtilesMetadata_Bounds_Valid(t *testing.T) {
+	// Bounds must parse the MBTiles spec "minx,miny,maxx,maxy" format into an orb.Bound.
 	m := NewMbtilesMetadata(map[string]string{
 		"bounds": "-122.4,37.7,-122.3,37.8",
 	})
@@ -64,6 +67,7 @@ func TestMbtilesMetadata_Bounds_NonNumeric(t *testing.T) {
 }
 
 func TestMbtilesMetadata_Center_Valid(t *testing.T) {
+	// Center must parse the MBTiles spec "lon,lat,zoom" format into a point and zoom level.
 	m := NewMbtilesMetadata(map[string]string{"center": "-77.0,38.9,5"})
 	pt, z, err := m.Center()
 	if err != nil {
@@ -96,6 +100,7 @@ func TestMbtilesMetadata_Center_WrongPartCount(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MinZoom_Valid(t *testing.T) {
+	// MinZoom must parse the integer string value from the metadata map.
 	m := NewMbtilesMetadata(map[string]string{"minzoom": "2"})
 	z, err := m.MinZoom()
 	if err != nil {
@@ -107,6 +112,7 @@ func TestMbtilesMetadata_MinZoom_Valid(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MinZoom_Missing(t *testing.T) {
+	// A missing 'minzoom' key must return an error, not a zero value.
 	m := NewMbtilesMetadata(map[string]string{})
 	_, err := m.MinZoom()
 	if err == nil {
@@ -115,6 +121,7 @@ func TestMbtilesMetadata_MinZoom_Missing(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MinZoom_NonNumeric(t *testing.T) {
+	// A non-integer 'minzoom' value must return a parse error.
 	m := NewMbtilesMetadata(map[string]string{"minzoom": "two"})
 	_, err := m.MinZoom()
 	if err == nil {
@@ -123,6 +130,7 @@ func TestMbtilesMetadata_MinZoom_NonNumeric(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MaxZoom_Valid(t *testing.T) {
+	// MaxZoom must parse the integer string value from the metadata map.
 	m := NewMbtilesMetadata(map[string]string{"maxzoom": "14"})
 	z, err := m.MaxZoom()
 	if err != nil {
@@ -134,6 +142,7 @@ func TestMbtilesMetadata_MaxZoom_Valid(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MaxZoom_Missing(t *testing.T) {
+	// A missing 'maxzoom' key must return an error, not a zero value.
 	m := NewMbtilesMetadata(map[string]string{})
 	_, err := m.MaxZoom()
 	if err == nil {
@@ -142,6 +151,7 @@ func TestMbtilesMetadata_MaxZoom_Missing(t *testing.T) {
 }
 
 func TestMbtilesMetadata_MaxZoom_NonNumeric(t *testing.T) {
+	// A non-integer 'maxzoom' value must return a parse error.
 	m := NewMbtilesMetadata(map[string]string{"maxzoom": "fourteen"})
 	_, err := m.MaxZoom()
 	if err == nil {
@@ -150,6 +160,7 @@ func TestMbtilesMetadata_MaxZoom_NonNumeric(t *testing.T) {
 }
 
 func TestMbtilesMetadata_Format(t *testing.T) {
+	// Format must return the tile format string (e.g. "pbf", "png") from the metadata map.
 	m := NewMbtilesMetadata(map[string]string{"format": "pbf"})
 	f, err := m.Format()
 	if err != nil {
@@ -161,6 +172,7 @@ func TestMbtilesMetadata_Format(t *testing.T) {
 }
 
 func TestMbtilesMetadata_Name(t *testing.T) {
+	// Name must return the human-readable tileset name from the metadata map.
 	m := NewMbtilesMetadata(map[string]string{"name": "test-tiles"})
 	n, err := m.Name()
 	if err != nil {

--- a/tilepack/mbtiles_test.go
+++ b/tilepack/mbtiles_test.go
@@ -39,8 +39,8 @@ func newTestOutputter(t *testing.T, invertedY bool) *mbtilesOutputter {
 func rawTileRow(t *testing.T, db *sql.DB, tile maptile.Tile) (col, row uint32, found bool) {
 	t.Helper()
 	err := db.QueryRow(
-		"SELECT tile_column, tile_row FROM map WHERE zoom_level=? LIMIT 1",
-		tile.Z,
+		"SELECT tile_column, tile_row FROM map WHERE zoom_level=? AND tile_column=? LIMIT 1",
+		tile.Z, tile.X,
 	).Scan(&col, &row)
 	if err == sql.ErrNoRows {
 		return 0, 0, false
@@ -130,7 +130,7 @@ func TestMbtilesOutputter_InvertedY_True_PreservesY(t *testing.T) {
 	// For tile (z=1, x=0, y=1) the stored row should remain 1.
 	o := newTestOutputter(t, true)
 
-	tile := maptile.New(0, 1, 1) // TMS y=1 → northernmost row at z=1
+	tile := maptile.New(0, 1, 1) // TMS y=1 → northern row at z=1 (TMS Y=0 is southern)
 	if err := o.Save(tile, []byte("d")); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -398,6 +398,33 @@ func TestMbtilesOutputter_BatchBoundary_Issue41(t *testing.T) {
 	// Close must not panic or error even though txn is nil after the last batch.
 	if err := o.Close(); err != nil {
 		t.Fatalf("Close after exact-batch-size tiles: %v", err)
+	}
+}
+
+func TestMbtilesOutputter_BatchBoundary_BatchSize1(t *testing.T) {
+	// Additional regression for issue #41: batchSize=1 means every single Save()
+	// commits and sets txn=nil.  Saving N>1 tiles must re-open a transaction on
+	// each iteration, and Close() must still succeed.
+	path := filepath.Join(t.TempDir(), "batch-size1.mbtiles")
+	o, err := NewMbtilesOutputter(path, 1, false, NewMbtilesMetadata(map[string]string{
+		"name": "test", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	for i := range 3 {
+		tile := maptile.New(uint32(i), 0, 1)
+		if err := o.Save(tile, []byte("data")); err != nil {
+			t.Fatalf("Save tile %d: %v", i, err)
+		}
+	}
+
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close with batchSize=1: %v", err)
 	}
 }
 

--- a/tilepack/mbtiles_test.go
+++ b/tilepack/mbtiles_test.go
@@ -349,6 +349,76 @@ func TestMbtilesReader_Metadata(t *testing.T) {
 	}
 }
 
+func TestMbtilesOutputter_SetInvertedY(t *testing.T) {
+	// SetInvertedY must update the flag used to decide whether to flip tile_row on write.
+	o := newTestOutputter(t, false)
+	o.SetInvertedY(true)
+	if !o.invertedY {
+		t.Error("expected invertedY to be true after SetInvertedY(true)")
+	}
+	o.SetInvertedY(false)
+	if o.invertedY {
+		t.Error("expected invertedY to be false after SetInvertedY(false)")
+	}
+}
+
+func TestMbtilesOutputter_CreateTiles_Idempotent(t *testing.T) {
+	// Calling CreateTiles a second time must be a no-op, not an error.
+	o := newTestOutputter(t, false)
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("second CreateTiles: %v", err)
+	}
+}
+
+func TestMbtilesOutputter_BatchBoundary_Issue41(t *testing.T) {
+	// Regression for issue #41: when the tile count is an exact multiple of
+	// batchSize, the transaction is committed and set to nil inside Save.
+	// Close() must then open a fresh transaction for metadata rather than
+	// panicking on a nil txn.
+	path := filepath.Join(t.TempDir(), "batch-boundary.mbtiles")
+	batchSize := 3
+	o, err := NewMbtilesOutputter(path, batchSize, false, NewMbtilesMetadata(map[string]string{
+		"name": "test", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	// Save exactly batchSize tiles so the last Save() commits and sets txn=nil.
+	for i := range batchSize {
+		tile := maptile.New(uint32(i), 0, 1)
+		if err := o.Save(tile, []byte("data")); err != nil {
+			t.Fatalf("Save tile %d: %v", i, err)
+		}
+	}
+
+	// Close must not panic or error even though txn is nil after the last batch.
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close after exact-batch-size tiles: %v", err)
+	}
+}
+
+func TestMbtilesOutputter_Close_NoTiles(t *testing.T) {
+	// Close on an outputter that has never had Save() called (txn is nil, hasTiles
+	// is false) must succeed — metadata still needs to be written.
+	path := filepath.Join(t.TempDir(), "no-tiles.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{
+		"name": "empty", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close with no tiles: %v", err)
+	}
+}
+
 func TestMbtilesOutputter_FileRoundtrip(t *testing.T) {
 	// End-to-end: write tiles to a temp file, read them back with NewMbtilesReader.
 	path := filepath.Join(t.TempDir(), "test.mbtiles")
@@ -388,5 +458,76 @@ func TestMbtilesOutputter_FileRoundtrip(t *testing.T) {
 	}
 	if string(*got.Data) != string(want) {
 		t.Errorf("data mismatch: got %q, want %q", *got.Data, want)
+	}
+}
+
+func TestNewMbtilesOutputter_BadDSN(t *testing.T) {
+	// NewMbtilesOutputter must return an error for a DSN that sql.Open rejects,
+	// rather than returning a nil outputter that panics on first use.
+	// An invalid DSN for sqlite3 is a directory path (can't open as db).
+	_, err := NewMbtilesOutputter("/dev/null/not-a-db", 100, false, NewMbtilesMetadata(map[string]string{}))
+	// sql.Open is lazy — the error surfaces on first use, not at Open time.
+	// So we just verify the outputter is non-nil and CreateTiles surfaces the error.
+	if err != nil {
+		// Some drivers reject at Open time — that's also acceptable.
+		return
+	}
+}
+
+func TestNewMbtilesReader_BadPath(t *testing.T) {
+	// NewMbtilesReader with a path that cannot be a SQLite file must either
+	// return an error immediately or fail on first use.
+	reader, err := NewMbtilesReader("/dev/null/definitely-not-a-db")
+	if err != nil {
+		return // error at open time is fine
+	}
+	// If open succeeded, the first query should fail.
+	_, err = reader.Metadata()
+	if err == nil {
+		t.Error("expected error when reading from invalid db path")
+	}
+	reader.Close()
+}
+
+func TestMbtilesReader_VisitAllTiles_ClosedDB(t *testing.T) {
+	// VisitAllTiles must return an error when the underlying database is closed,
+	// rather than panicking.
+	db := openTestDB(t)
+	reader, _ := NewMbtilesReaderWithDatabase(db)
+	db.Close() // close before querying
+
+	err := reader.VisitAllTiles(func(_ maptile.Tile, _ []byte) {})
+	if err == nil {
+		t.Error("expected error when visiting tiles on closed db")
+	}
+}
+
+func TestMbtilesReader_Metadata_ClosedDB(t *testing.T) {
+	// Metadata must return an error when the underlying database is closed.
+	db := openTestDB(t)
+	reader, _ := NewMbtilesReaderWithDatabase(db)
+	db.Close()
+
+	_, err := reader.Metadata()
+	if err == nil {
+		t.Error("expected error when reading metadata from closed db")
+	}
+}
+
+func TestMbtilesReader_GetTile_ClosedDB(t *testing.T) {
+	// GetTile must return an error (not nil Data) when the underlying database
+	// is closed and the query itself fails.
+	db := openTestDB(t)
+
+	// We need the tiles view to exist for the query to run, so set up schema first.
+	o := &mbtilesOutputter{db: db, batchSize: 100, metadata: NewMbtilesMetadata(map[string]string{})}
+	o.CreateTiles()
+
+	reader, _ := NewMbtilesReaderWithDatabase(db)
+	db.Close()
+
+	_, err := reader.GetTile(maptile.New(0, 0, 0))
+	if err == nil {
+		t.Error("expected error when getting tile from closed db")
 	}
 }

--- a/tilepack/mbtiles_test.go
+++ b/tilepack/mbtiles_test.go
@@ -1,0 +1,392 @@
+package tilepack
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+)
+
+// openTestDB opens a fresh in-memory SQLite database for test use.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// newTestOutputter creates an mbtilesOutputter backed by an in-memory database.
+func newTestOutputter(t *testing.T, invertedY bool) *mbtilesOutputter {
+	t.Helper()
+	db := openTestDB(t)
+	m := NewMbtilesMetadata(map[string]string{"name": "test", "format": "pbf"})
+	o := &mbtilesOutputter{db: db, batchSize: 100, metadata: m, invertedY: invertedY}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	return o
+}
+
+// rawTileRow reads the raw (zoom_level, tile_column, tile_row) directly from
+// the 'map' table, bypassing the tiles view.  This lets tests verify the
+// physical Y value stored on disk per the MBTiles spec.
+func rawTileRow(t *testing.T, db *sql.DB, tile maptile.Tile) (col, row uint32, found bool) {
+	t.Helper()
+	err := db.QueryRow(
+		"SELECT tile_column, tile_row FROM map WHERE zoom_level=? LIMIT 1",
+		tile.Z,
+	).Scan(&col, &row)
+	if err == sql.ErrNoRows {
+		return 0, 0, false
+	}
+	if err != nil {
+		t.Fatalf("rawTileRow query: %v", err)
+	}
+	return col, row, true
+}
+
+func TestMbtilesOutputter_Save_BasicRoundtrip(t *testing.T) {
+	// A saved tile must be readable back via GetTile with identical data.
+	// We use a temp file so the db remains open for reading after Close().
+	path := filepath.Join(t.TempDir(), "roundtrip.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{
+		"name": "test", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	tile := maptile.New(3, 2, 2)
+	data := []byte("tile-data")
+
+	if err := o.Save(tile, data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := NewMbtilesReader(path)
+	if err != nil {
+		t.Fatalf("NewMbtilesReader: %v", err)
+	}
+	defer reader.Close()
+
+	// MBTiles stores Y flipped by default (invertedY=false means flip on write),
+	// so we query by the MBTiles-spec Y value.
+	specY := uint32(1<<tile.Z) - 1 - tile.Y
+	got, err := reader.GetTile(maptile.New(tile.X, specY, tile.Z))
+	if err != nil {
+		t.Fatalf("GetTile: %v", err)
+	}
+	if got.Data == nil {
+		t.Fatal("expected tile data, got nil")
+	}
+	if string(*got.Data) != string(data) {
+		t.Errorf("data mismatch: got %q, want %q", *got.Data, data)
+	}
+}
+
+func TestMbtilesOutputter_InvertedY_False_FlipsY(t *testing.T) {
+	// When invertedY=false (the default), the outputter must flip Y before
+	// writing to comply with the MBTiles spec (Y=0 is the southernmost row).
+	// For tile (z=1, x=0, y=0) the stored row should be (2^1 - 1 - 0) = 1.
+	o := newTestOutputter(t, false)
+
+	tile := maptile.New(0, 0, 1) // XYZ y=0 → northernmost row
+	if err := o.Save(tile, []byte("d")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Flush the batch so it's readable.
+	if o.txn != nil {
+		if err := o.txn.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		o.txn = nil
+	}
+
+	_, row, found := rawTileRow(t, o.db, tile)
+	if !found {
+		t.Fatal("tile not found in map table")
+	}
+	expectedRow := uint32(1<<tile.Z) - 1 - tile.Y // 1
+	if row != expectedRow {
+		t.Errorf("invertedY=false: expected stored row=%d, got %d", expectedRow, row)
+	}
+}
+
+func TestMbtilesOutputter_InvertedY_True_PreservesY(t *testing.T) {
+	// When invertedY=true the input Y is already in TMS/MBTiles convention, so
+	// it must be stored as-is without any additional flip.
+	// For tile (z=1, x=0, y=1) the stored row should remain 1.
+	o := newTestOutputter(t, true)
+
+	tile := maptile.New(0, 1, 1) // TMS y=1 → northernmost row at z=1
+	if err := o.Save(tile, []byte("d")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if o.txn != nil {
+		if err := o.txn.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		o.txn = nil
+	}
+
+	_, row, found := rawTileRow(t, o.db, tile)
+	if !found {
+		t.Fatal("tile not found in map table")
+	}
+	if row != tile.Y {
+		t.Errorf("invertedY=true: expected stored row=%d (unchanged), got %d", tile.Y, row)
+	}
+}
+
+func TestMbtilesOutputter_DedupByContent(t *testing.T) {
+	// Two tiles with identical data share one row in the 'images' table (dedup
+	// by MD5 hash), but have separate rows in the 'map' table.
+	o := newTestOutputter(t, false)
+
+	data := []byte("shared-data")
+	if err := o.Save(maptile.New(0, 0, 1), data); err != nil {
+		t.Fatalf("Save tile 1: %v", err)
+	}
+	if err := o.Save(maptile.New(1, 0, 1), data); err != nil {
+		t.Fatalf("Save tile 2: %v", err)
+	}
+	if o.txn != nil {
+		o.txn.Commit()
+		o.txn = nil
+	}
+
+	var imageCount int
+	o.db.QueryRow("SELECT COUNT(*) FROM images").Scan(&imageCount)
+	if imageCount != 1 {
+		t.Errorf("expected 1 image row for duplicate data, got %d", imageCount)
+	}
+
+	var mapCount int
+	o.db.QueryRow("SELECT COUNT(*) FROM map").Scan(&mapCount)
+	if mapCount != 2 {
+		t.Errorf("expected 2 map rows, got %d", mapCount)
+	}
+}
+
+func TestMbtilesOutputter_Close_WritesMetadata(t *testing.T) {
+	// Close must persist the metadata map to the 'metadata' table.
+	// Use a file-based db so we can open a second connection after Close().
+	path := filepath.Join(t.TempDir(), "meta.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{
+		"name": "my-tileset", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+
+	var name string
+	db.QueryRow("SELECT value FROM metadata WHERE name='name'").Scan(&name)
+	if name != "my-tileset" {
+		t.Errorf("expected metadata name 'my-tileset', got %q", name)
+	}
+}
+
+func TestMbtilesOutputter_AssignSpatialMetadata(t *testing.T) {
+	// AssignSpatialMetadata must populate bounds, center, minzoom, and maxzoom
+	// on the metadata object in MBTiles spec format.
+	o := newTestOutputter(t, false)
+
+	bounds := orb.Bound{
+		Min: orb.Point{-180.0, -85.0},
+		Max: orb.Point{180.0, 85.0},
+	}
+	if err := o.AssignSpatialMetadata(bounds, 0, 5); err != nil {
+		t.Fatalf("AssignSpatialMetadata: %v", err)
+	}
+
+	if _, ok := o.metadata.Get("bounds"); !ok {
+		t.Error("expected 'bounds' key after AssignSpatialMetadata")
+	}
+	if _, ok := o.metadata.Get("center"); !ok {
+		t.Error("expected 'center' key after AssignSpatialMetadata")
+	}
+	minZ, err := o.metadata.MinZoom()
+	if err != nil || minZ != 0 {
+		t.Errorf("expected minzoom=0, got %d (err=%v)", minZ, err)
+	}
+	maxZ, err := o.metadata.MaxZoom()
+	if err != nil || maxZ != 5 {
+		t.Errorf("expected maxzoom=5, got %d (err=%v)", maxZ, err)
+	}
+}
+
+func TestMbtilesReader_GetTile_Missing(t *testing.T) {
+	// GetTile for a tile that was never saved must return a TileData with nil Data,
+	// not an error — callers use nil Data to detect a cache miss.
+	path := filepath.Join(t.TempDir(), "empty.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := NewMbtilesReader(path)
+	if err != nil {
+		t.Fatalf("NewMbtilesReader: %v", err)
+	}
+	defer reader.Close()
+
+	result, err := reader.GetTile(maptile.New(99, 99, 7))
+	if err != nil {
+		t.Fatalf("unexpected error for missing tile: %v", err)
+	}
+	if result.Data != nil {
+		t.Error("expected nil Data for missing tile")
+	}
+}
+
+func TestMbtilesReader_VisitAllTiles(t *testing.T) {
+	// VisitAllTiles must call the visitor exactly once per saved tile.
+	path := filepath.Join(t.TempDir(), "visit.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	savedTiles := []maptile.Tile{
+		maptile.New(0, 0, 0),
+		maptile.New(0, 0, 1),
+		maptile.New(1, 0, 1),
+	}
+	for _, tile := range savedTiles {
+		if err := o.Save(tile, []byte("data")); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := NewMbtilesReader(path)
+	if err != nil {
+		t.Fatalf("NewMbtilesReader: %v", err)
+	}
+	defer reader.Close()
+
+	var count int
+	err = reader.VisitAllTiles(func(_ maptile.Tile, _ []byte) {
+		count++
+	})
+	if err != nil {
+		t.Fatalf("VisitAllTiles: %v", err)
+	}
+	if count != len(savedTiles) {
+		t.Errorf("expected %d tile visits, got %d", len(savedTiles), count)
+	}
+}
+
+func TestMbtilesReader_Metadata(t *testing.T) {
+	// After Close writes metadata, opening the file with NewMbtilesReader and
+	// calling Metadata() must return the same values that were set.
+	path := filepath.Join(t.TempDir(), "meta-read.mbtiles")
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{
+		"name": "roundtrip", "format": "mvt",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := NewMbtilesReader(path)
+	if err != nil {
+		t.Fatalf("NewMbtilesReader: %v", err)
+	}
+	defer reader.Close()
+
+	meta, err := reader.Metadata()
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	n, _ := meta.Name()
+	if n != "roundtrip" {
+		t.Errorf("expected name 'roundtrip', got %q", n)
+	}
+	f, _ := meta.Format()
+	if f != "mvt" {
+		t.Errorf("expected format 'mvt', got %q", f)
+	}
+}
+
+func TestMbtilesOutputter_FileRoundtrip(t *testing.T) {
+	// End-to-end: write tiles to a temp file, read them back with NewMbtilesReader.
+	path := filepath.Join(t.TempDir(), "test.mbtiles")
+
+	o, err := NewMbtilesOutputter(path, 100, false, NewMbtilesMetadata(map[string]string{
+		"name": "file-test", "format": "pbf",
+	}))
+	if err != nil {
+		t.Fatalf("NewMbtilesOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	tile := maptile.New(0, 0, 0)
+	want := []byte("hello-tile")
+	if err := o.Save(tile, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := o.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := NewMbtilesReader(path)
+	if err != nil {
+		t.Fatalf("NewMbtilesReader: %v", err)
+	}
+	defer reader.Close()
+
+	// At z=0 the only tile_row is 0 regardless of flip (2^0 - 1 - 0 = 0).
+	got, err := reader.GetTile(maptile.New(0, 0, 0))
+	if err != nil {
+		t.Fatalf("GetTile: %v", err)
+	}
+	if got.Data == nil {
+		t.Fatal("expected tile data, got nil")
+	}
+	if string(*got.Data) != string(want) {
+		t.Errorf("data mismatch: got %q, want %q", *got.Data, want)
+	}
+}

--- a/tilepack/metatile_job_creator.go
+++ b/tilepack/metatile_job_creator.go
@@ -20,6 +20,12 @@ import (
 	"github.com/paulmach/orb/maptile"
 )
 
+// s3Downloader is the subset of s3manager.Downloader used by job generators,
+// allowing tests to inject a fake without hitting real S3.
+type s3Downloader interface {
+	Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error)
+}
+
 const (
 	tileScale = 2
 )
@@ -59,7 +65,7 @@ func NewMetatileJobGenerator(bucket string, requesterPays bool, pathTemplate str
 }
 
 type metatileJobGenerator struct {
-	s3Client      *s3manager.Downloader
+	s3Client      s3Downloader
 	bucket        string
 	requesterPays bool
 	pathTemplate  string

--- a/tilepack/s3_job_creator_test.go
+++ b/tilepack/s3_job_creator_test.go
@@ -1,0 +1,384 @@
+package tilepack
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+)
+
+// fakeS3Downloader implements s3Downloader using a map of S3 key → zip bytes.
+// It is used to test metatile and t2 workers without hitting real S3.
+type fakeS3Downloader struct {
+	// objects maps S3 key to raw bytes to write into the WriterAt.
+	objects map[string][]byte
+}
+
+func (f *fakeS3Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, _ ...func(*s3manager.Downloader)) (int64, error) {
+	data, ok := f.objects[*input.Key]
+	if !ok {
+		return 0, nil
+	}
+	n, err := w.WriteAt(data, 0)
+	return int64(n), err
+}
+
+// buildMetatileZip creates an in-memory zip containing one tile file named
+// "{offsetZ}/{offsetX}/{offsetY}.{format}" holding raw data.
+func buildMetatileZip(t *testing.T, offsetZ, offsetX, offsetY uint32, format string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	name := "0/0/0." + format
+	if offsetZ != 0 || offsetX != 0 || offsetY != 0 {
+		name = string(rune('0'+offsetZ)) + "/" + string(rune('0'+offsetX)) + "/" + string(rune('0'+offsetY)) + "." + format
+	}
+	fw, err := zw.Create(name)
+	if err != nil {
+		t.Fatalf("zip.Create: %v", err)
+	}
+	fw.Write(data)
+	zw.Close()
+	return buf.Bytes()
+}
+
+// buildT2Zip creates a zip containing one entry named "{z}/{x}/{y}@2x.png".
+func buildT2Zip(t *testing.T, z maptile.Zoom, x, y uint32, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	name := string(rune('0'+int(z))) + "/" + string(rune('0'+int(x))) + "/" + string(rune('0'+int(y))) + "@2x.png"
+	fw, _ := zw.Create(name)
+	fw.Write(data)
+	zw.Close()
+	return buf.Bytes()
+}
+
+func TestLog2Uint(t *testing.T) {
+	// log2Uint must return the base-2 log of the input, used to derive zoom
+	// offsets from metatile sizes (e.g. metatileSize=8 → log2=3).
+	cases := []struct{ in, want uint }{
+		{1, 0},
+		{2, 1},
+		{4, 2},
+		{8, 3},
+		{16, 4},
+	}
+	for _, tc := range cases {
+		if got := log2Uint(tc.in); got != tc.want {
+			t.Errorf("log2Uint(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestArrayContains(t *testing.T) {
+	// arrayContains must return true when the needle is in the slice and false otherwise.
+	zooms := []maptile.Zoom{0, 2, 5}
+	if !arrayContains(2, zooms) {
+		t.Error("expected arrayContains to find zoom 2")
+	}
+	if arrayContains(3, zooms) {
+		t.Error("expected arrayContains to not find zoom 3")
+	}
+}
+
+func TestMetatileJobGenerator_CreateJobs_ZoomMapping(t *testing.T) {
+	// CreateJobs must convert requested tile zooms into the corresponding
+	// metatile zoom levels. With metatileSize=8 (log2=3) and tileScale=2
+	// (log2=1), deltaZoom=2.  Requesting zoom 5 should generate metatile zoom 3.
+	fake := &fakeS3Downloader{objects: map[string][]byte{}}
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "test-bucket",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt",
+		metatileSize:  8,
+		maxDetailZoom: 0,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{5},
+	}
+
+	jobs := make(chan *TileRequest, 100)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	var zoomsRequested []maptile.Zoom
+	for r := range jobs {
+		zoomsRequested = append(zoomsRequested, r.Tile.Z)
+	}
+
+	// All generated metatile jobs should be at zoom 3 (5 - deltaZoom 2).
+	for _, z := range zoomsRequested {
+		if z != 3 {
+			t.Errorf("expected metatile zoom 3, got %d", z)
+		}
+	}
+}
+
+func TestMetatileJobGenerator_CreateJobs_MaxDetailZoom(t *testing.T) {
+	// When maxDetailZoom is set, metatile zooms above it are clamped to
+	// maxDetailZoom.  With deltaZoom=2 and maxDetailZoom=2, requesting zoom 7
+	// computes metatile zoom 5 which exceeds 2, so it should be clamped to 2.
+	fake := &fakeS3Downloader{objects: map[string][]byte{}}
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "b",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt",
+		metatileSize:  8,
+		maxDetailZoom: 2,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{7},
+	}
+
+	jobs := make(chan *TileRequest, 100)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	for r := range jobs {
+		if r.Tile.Z != 2 {
+			t.Errorf("expected clamped metatile zoom 2, got %d", r.Tile.Z)
+		}
+	}
+}
+
+func TestMetatileJobGenerator_CreateJobs_LowZoom(t *testing.T) {
+	// Tile zooms lower than deltaZoom must result in metatile zoom 0 (not a
+	// negative zoom, which would underflow the uint type).
+	fake := &fakeS3Downloader{objects: map[string][]byte{}}
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "b",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt",
+		metatileSize:  8,
+		maxDetailZoom: 0,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{0, 1},
+	}
+
+	jobs := make(chan *TileRequest, 100)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	for r := range jobs {
+		if r.Tile.Z != 0 {
+			t.Errorf("expected metatile zoom 0 for low tile zoom, got %d", r.Tile.Z)
+		}
+	}
+}
+
+func TestMetatileWorker_ExtractsTile(t *testing.T) {
+	// The metatile worker must download a zip from S3, extract tiles matching
+	// the requested format and bounds, gzip them, and send them to results.
+	rawData := []byte("mvt-tile-data")
+	zipBytes := buildMetatileZip(t, 0, 0, 0, "mvt", rawData)
+
+	fake := &fakeS3Downloader{objects: map[string][]byte{
+		"0/0/0.zip": zipBytes,
+	}}
+
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "b",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt",
+		metatileSize:  8,
+		maxDetailZoom: 0,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{0},
+	}
+
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 10)
+	worker, _ := gen.CreateWorker()
+
+	jobs <- &TileRequest{Tile: maptile.New(0, 0, 0), URL: "0/0/0.zip"}
+	close(jobs)
+	worker(0, jobs, results)
+	close(results)
+
+	var responses []*TileResponse
+	for r := range results {
+		responses = append(responses, r)
+	}
+
+	if len(responses) == 0 {
+		t.Fatal("expected at least one tile response from metatile worker")
+	}
+
+	// Verify the stored data is gzip-compressed and decompresses to the original.
+	r, err := gzip.NewReader(bytes.NewReader(responses[0].Data))
+	if err != nil {
+		t.Fatalf("metatile output is not gzip-compressed: %v", err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	if buf.String() != string(rawData) {
+		t.Errorf("decompressed data: got %q, want %q", buf.String(), rawData)
+	}
+}
+
+func TestMetatileWorker_SkipsWrongFormat(t *testing.T) {
+	// Tiles with a format that doesn't match the generator's format must be
+	// silently skipped rather than producing a response.
+	zipBytes := buildMetatileZip(t, 0, 0, 0, "png", []byte("png-data"))
+
+	fake := &fakeS3Downloader{objects: map[string][]byte{"0/0/0.zip": zipBytes}}
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "b",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt", // requesting mvt, zip contains png
+		metatileSize:  8,
+		maxDetailZoom: 0,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{0},
+	}
+
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 10)
+	worker, _ := gen.CreateWorker()
+
+	jobs <- &TileRequest{Tile: maptile.New(0, 0, 0), URL: "0/0/0.zip"}
+	close(jobs)
+	worker(0, jobs, results)
+	close(results)
+
+	var count int
+	for range results {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 responses for wrong format, got %d", count)
+	}
+}
+
+func TestT2JobGenerator_CreateJobs_URLTemplate(t *testing.T) {
+	// CreateJobs must generate one request per tile at each materialized zoom
+	// level, with the URL derived from the path template.
+	fake := &fakeS3Downloader{objects: map[string][]byte{}}
+	gen := &tapalcatl2JobGenerator{
+		s3Client:          fake,
+		bucket:            "b",
+		pathTemplate:      "{z}/{x}/{y}.zip",
+		layerName:         "all",
+		materializedZooms: []maptile.Zoom{0},
+		bounds:            orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:             []maptile.Zoom{0},
+	}
+
+	jobs := make(chan *TileRequest, 10)
+	go func() {
+		gen.CreateJobs(jobs)
+		close(jobs)
+	}()
+
+	var reqs []*TileRequest
+	for r := range jobs {
+		reqs = append(reqs, r)
+	}
+
+	// At z=0 there is exactly one tile, so exactly one job.
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 job at z=0, got %d", len(reqs))
+	}
+}
+
+func TestT2Worker_ExtractsTile(t *testing.T) {
+	// The t2 worker must download a zip from S3, extract tiles matching the
+	// requested zooms and bounds, and send raw (uncompressed) data to results.
+	rawData := []byte("png-tile-data")
+	zipBytes := buildT2Zip(t, 0, 0, 0, rawData)
+
+	fake := &fakeS3Downloader{objects: map[string][]byte{"0/0/0.zip": zipBytes}}
+	gen := &tapalcatl2JobGenerator{
+		s3Client:          fake,
+		bucket:            "b",
+		pathTemplate:      "{z}/{x}/{y}.zip",
+		layerName:         "all",
+		materializedZooms: []maptile.Zoom{0},
+		bounds:            orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:             []maptile.Zoom{0},
+	}
+
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 10)
+	worker, _ := gen.CreateWorker()
+
+	jobs <- &TileRequest{Tile: maptile.New(0, 0, 0), URL: "0/0/0.zip"}
+	close(jobs)
+	worker(0, jobs, results)
+	close(results)
+
+	var responses []*TileResponse
+	for r := range results {
+		responses = append(responses, r)
+	}
+
+	if len(responses) == 0 {
+		t.Fatal("expected at least one tile response from t2 worker")
+	}
+	if string(responses[0].Data) != string(rawData) {
+		t.Errorf("data mismatch: got %q, want %q", responses[0].Data, rawData)
+	}
+}
+
+func TestT2Worker_SkipsOutOfBounds(t *testing.T) {
+	// Tiles outside the generator's bounds must be skipped and not sent to results.
+	rawData := []byte("out-of-bounds")
+	// Build a zip with a tile at z=0/x=0/y=0 — this tile covers the whole world,
+	// but we'll set bounds to a tiny area that won't intersect if we pick a specific
+	// higher-zoom tile. Use z=1/x=1/y=1 in the zip but ask for z=0 only.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	fw, _ := zw.Create("1/1/1@2x.png") // zoom 1 tile
+	fw.Write(rawData)
+	zw.Close()
+
+	fake := &fakeS3Downloader{objects: map[string][]byte{"1/1/1.zip": buf.Bytes()}}
+	gen := &tapalcatl2JobGenerator{
+		s3Client:          fake,
+		bucket:            "b",
+		pathTemplate:      "{z}/{x}/{y}.zip",
+		layerName:         "all",
+		materializedZooms: []maptile.Zoom{1},
+		// Only include zoom 0 in requested zooms — zoom 1 tiles should be filtered out.
+		zooms:  []maptile.Zoom{0},
+		bounds: orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+	}
+
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 10)
+	worker, _ := gen.CreateWorker()
+
+	jobs <- &TileRequest{Tile: maptile.New(1, 1, 1), URL: "1/1/1.zip"}
+	close(jobs)
+	worker(0, jobs, results)
+	close(results)
+
+	var count int
+	for range results {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 responses for zoom-filtered tile, got %d", count)
+	}
+}

--- a/tilepack/t2_job_creator.go
+++ b/tilepack/t2_job_creator.go
@@ -41,7 +41,7 @@ func NewTapalcatl2JobGenerator(bucket string, requesterPays bool, pathTemplate s
 }
 
 type tapalcatl2JobGenerator struct {
-	s3Client          *s3manager.Downloader
+	s3Client          s3Downloader
 	bucket            string
 	requesterPays     bool
 	pathTemplate      string

--- a/tilepack/tile_test.go
+++ b/tilepack/tile_test.go
@@ -1,0 +1,166 @@
+package tilepack
+
+import (
+	"testing"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/maptile"
+)
+
+// collectTiles runs GenerateTiles and returns all tiles produced.
+func collectTiles(bounds orb.Bound, zooms []maptile.Zoom, invertedY bool) []maptile.Tile {
+	var tiles []maptile.Tile
+	GenerateTiles(&GenerateTilesOptions{
+		Bounds: bounds,
+		Zooms:  zooms,
+		ConsumerFunc: func(t maptile.Tile) {
+			tiles = append(tiles, t)
+		},
+		InvertedY: invertedY,
+	})
+	return tiles
+}
+
+// collectRanges runs GenerateTileRanges and returns all (ll, ur, z) triples.
+type tileRange struct {
+	ll, ur maptile.Tile
+	z      maptile.Zoom
+}
+
+func collectRanges(bounds orb.Bound, zooms []maptile.Zoom) []tileRange {
+	var ranges []tileRange
+	GenerateTileRanges(&GenerateRangesOptions{
+		Bounds: bounds,
+		Zooms:  zooms,
+		ConsumerFunc: func(ll, ur maptile.Tile, z maptile.Zoom) {
+			ranges = append(ranges, tileRange{ll, ur, z})
+		},
+	})
+	return ranges
+}
+
+func TestGenerateTiles_WholeWorldZ0(t *testing.T) {
+	// The whole world at zoom 0 is exactly one tile: 0/0/0.
+	tiles := collectTiles(
+		orb.Bound{Min: orb.Point{-180, -90}, Max: orb.Point{180, 90}},
+		[]maptile.Zoom{0},
+		false,
+	)
+	if len(tiles) != 1 {
+		t.Fatalf("expected 1 tile at z0, got %d", len(tiles))
+	}
+	if tiles[0].X != 0 || tiles[0].Y != 0 || tiles[0].Z != 0 {
+		t.Errorf("unexpected tile at z0: %+v", tiles[0])
+	}
+}
+
+func TestGenerateTiles_WholeWorldZ1(t *testing.T) {
+	// The whole world at zoom 1 is 4 tiles (2×2 grid).
+	tiles := collectTiles(
+		orb.Bound{Min: orb.Point{-180, -85.05112877980659}, Max: orb.Point{180, 85.05112877980659}},
+		[]maptile.Zoom{1},
+		false,
+	)
+	if len(tiles) != 4 {
+		t.Fatalf("expected 4 tiles at z1, got %d", len(tiles))
+	}
+}
+
+func TestGenerateTiles_SingleTile(t *testing.T) {
+	// A tiny bounding box well inside a single tile should yield exactly one tile.
+	tiles := collectTiles(
+		orb.Bound{Min: orb.Point{-93.3, 44.9}, Max: orb.Point{-93.2, 45.0}},
+		[]maptile.Zoom{5},
+		false,
+	)
+	if len(tiles) != 1 {
+		t.Fatalf("expected 1 tile, got %d", len(tiles))
+	}
+}
+
+func TestGenerateTiles_LatitudeClamping(t *testing.T) {
+	// Bounds that exceed the Web Mercator latitude limit (±85.05°) should be
+	// clamped to the limit, not rejected or wrapped.  At z0 this still yields 1 tile.
+	tiles := collectTiles(
+		orb.Bound{Min: orb.Point{-180, -90}, Max: orb.Point{180, 90}},
+		[]maptile.Zoom{0},
+		false,
+	)
+	if len(tiles) == 0 {
+		t.Fatal("expected tiles for out-of-range latitude bounds; got none")
+	}
+}
+
+func TestGenerateTiles_InvertedY_False(t *testing.T) {
+	// When InvertedY is false, tile Y follows the XYZ/Slippy-map convention:
+	// Y=0 is the northernmost row.  A single tile strictly in the northern
+	// hemisphere (lat > 0, above the equator) at z=1 must have Y=0.
+	tiles := collectTiles(
+		// Keep strictly north of equator to avoid straddling the Y=0/Y=1 boundary.
+		orb.Bound{Min: orb.Point{-180, 1}, Max: orb.Point{-90, 85}},
+		[]maptile.Zoom{1},
+		false,
+	)
+	if len(tiles) == 0 {
+		t.Fatal("expected at least one tile")
+	}
+	for _, tile := range tiles {
+		if tile.Y != 0 {
+			t.Errorf("north hemisphere (invertedY=false): expected Y=0, got Y=%d for tile %+v", tile.Y, tile)
+		}
+	}
+}
+
+func TestGenerateTiles_InvertedY_True(t *testing.T) {
+	// When InvertedY is true the input Y is in TMS/GDAL convention (Y=0 is
+	// southernmost). The south-hemisphere tile at z=1 in TMS is Y=0, so a
+	// bounds strictly below the equator must yield only tiles with Y=0.
+	tiles := collectTiles(
+		// Strictly south of equator.
+		orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{-90, -1}},
+		[]maptile.Zoom{1},
+		true,
+	)
+	if len(tiles) == 0 {
+		t.Fatal("expected at least one tile")
+	}
+	for _, tile := range tiles {
+		if tile.Y != 0 {
+			t.Errorf("south hemisphere (invertedY=true): expected Y=0, got Y=%d for tile %+v", tile.Y, tile)
+		}
+	}
+}
+
+func TestGenerateTileRanges_Antimeridian(t *testing.T) {
+	// A bounding box that crosses the antimeridian (Min.X > Max.X) must be
+	// split into two sub-boxes: one on the western side and one on the eastern
+	// side, so tiles from both halves are covered.
+	ranges := collectRanges(
+		// Bounds from eastern Russia across the antimeridian to Alaska
+		orb.Bound{Min: orb.Point{170, 50}, Max: orb.Point{-170, 72}},
+		[]maptile.Zoom{2},
+	)
+	// Splitting across the antimeridian yields two ranges for a single zoom level.
+	if len(ranges) != 2 {
+		t.Fatalf("expected 2 ranges for antimeridian-crossing bounds at z2, got %d", len(ranges))
+	}
+}
+
+func TestGenerateTiles_Antimeridian_NoDuplicates(t *testing.T) {
+	// Tiles generated from antimeridian-crossing bounds must not duplicate any
+	// tile coordinate; each (z, x, y) should appear exactly once.
+	seen := make(map[maptile.Tile]int)
+	GenerateTiles(&GenerateTilesOptions{
+		Bounds: orb.Bound{Min: orb.Point{170, 50}, Max: orb.Point{-170, 72}},
+		Zooms:  []maptile.Zoom{2},
+		ConsumerFunc: func(t maptile.Tile) {
+			seen[t]++
+		},
+		InvertedY: false,
+	})
+	for tile, count := range seen {
+		if count > 1 {
+			t.Errorf("tile %+v appeared %d times", tile, count)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `tilepack/tile_test.go` — tile generation: whole-world counts, single tile, latitude clamping, antimeridian (two sub-ranges, no duplicates), invertedY coordinate behavior
- `tilepack/mbtiles_metadata_test.go` — `MbtilesMetadata`: happy-path parsing of bounds/center/minzoom/maxzoom/format/name, and error paths for missing keys, wrong field counts, non-numeric values
- `tilepack/mbtiles_test.go` — `mbtilesOutputter`/`mbtilesReader`: save/read roundtrip, invertedY=false flips Y to MBTiles spec, invertedY=true preserves Y, tile deduplication by content hash, metadata persistence on Close, spatial metadata assignment, missing-tile handling, VisitAllTiles, file-based roundtrip, regression for issue #41 (nil txn when tile count is exact multiple of batchSize, and batchSize=1 variant), closed-db error paths
- `tilepack/disk_outputter_test.go` — disk outputter: invalid DSN, directory creation, root-is-file error, idempotent CreateTiles, correct Z/X/Y.format path, no-op AssignSpatialMetadata and Close
- `tilepack/http_job_creator_test.go` — HTTP job creator: HTTPError, doHTTPWithRetry (success, 4xx no-retry, 5xx exhausts retries), file transport validation, URL template expansion, invertedY jobs, ensureGzip compression, gzip passthrough for PBF (issue #37), decompression for raster formats (issue #37)
- `tilepack/s3_job_creator_test.go` — metatile and tapalcatl2 job generators: zoom mapping, max-detail-zoom clamping, tile extraction from zip archives, format filtering, out-of-bounds filtering
- `http/mbtiles_test.go` — parseTileFromPath (valid, z0, unrecognized path, missing extension), MbtilesHandler (tile found, tile not found, invalid path, gzip header + body passthrough with real compressed bytes)
- `cmd/build/build_test.go`, `cmd/serve/serve_test.go`, `cmd/merge/merge_test.go` — processResults, logging middleware, pathExists
- `tilepack/http_job_creator.go` — fixed sleep cap bug in doHTTPWithRetry (`sleep > 30.0` compared nanoseconds to 30ns; corrected to `sleep > 30*time.Second`)