### PR TITLE
Fix correctness and performance issues in tile workers and outputters

### DIFF
--- a/tilepack/disk_outputter.go
+++ b/tilepack/disk_outputter.go
@@ -96,7 +96,7 @@ func (o *diskOutputter) Save(tile maptile.Tile, data []byte) error {
 		return err
 	}
 
-	fh, err := os.OpenFile(absPath, os.O_RDWR|os.O_CREATE, 0644)
+	fh, err := os.OpenFile(absPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/tilepack/disk_outputter_test.go
+++ b/tilepack/disk_outputter_test.go
@@ -167,3 +167,33 @@ func TestDiskOutputter_Close(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 }
+
+func TestDiskOutputter_Save_OverwriteTruncates(t *testing.T) {
+	// Re-saving a tile with shorter content must not leave stale trailing bytes.
+	// Regression for the O_RDWR|O_CREATE (no O_TRUNC) bug: without O_TRUNC, the
+	// old tail survives and the file length is the max of old and new content.
+	dir := t.TempDir()
+	o, err := NewDiskOutputter("root=" + dir + " format=pbf")
+	if err != nil {
+		t.Fatalf("NewDiskOutputter: %v", err)
+	}
+	if err := o.CreateTiles(); err != nil {
+		t.Fatalf("CreateTiles: %v", err)
+	}
+
+	tile := maptile.New(0, 0, 0)
+	if err := o.Save(tile, []byte("long-original-data")); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if err := o.Save(tile, []byte("short")); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "0/0/0.pbf"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "short" {
+		t.Errorf("expected %q after overwrite, got %q", "short", got)
+	}
+}

--- a/tilepack/http_job_creator.go
+++ b/tilepack/http_job_creator.go
@@ -141,7 +141,10 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 
 		// Instantiate the gzip support stuff once instead on every iteration
 		bodyBuffer := bytes.NewBuffer(nil)
-		bodyGzipper := gzip.NewWriter(bodyBuffer)
+		bodyGzipper, err := gzip.NewWriterLevel(bodyBuffer, gzip.BestCompression)
+		if err != nil {
+			log.Fatalf("Couldn't create gzipper: %+v", err)
+		}
 
 		for request := range jobs {
 			start := time.Now()
@@ -204,9 +207,9 @@ func (x *xyzJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, r
 						continue
 					}
 
-					err = bodyGzipper.Flush()
+					err = bodyGzipper.Close()
 					if err != nil {
-						log.Printf("Couldn't flush gzipper: %+v", err)
+						log.Printf("Couldn't close gzipper: %+v", err)
 						continue
 					}
 

--- a/tilepack/http_job_creator_test.go
+++ b/tilepack/http_job_creator_test.go
@@ -3,6 +3,7 @@ package tilepack
 import (
 	"compress/gzip"
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -336,5 +337,31 @@ func TestFileTransportXYZWorker_FetchesTile(t *testing.T) {
 	resp := runWorker(t, gen, "file:///0/0/0.pbf", maptile.New(0, 0, 0))
 	if string(resp.Data) != string(tileData) {
 		t.Errorf("expected %q, got %q", tileData, resp.Data)
+	}
+}
+
+func TestXYZWorker_EnsureGzip_ValidTrailer(t *testing.T) {
+	// Regression for gzip.Flush() vs gzip.Close(): Flush() writes a sync-flush
+	// block but omits the CRC32/ISIZE trailer required by RFC 1952. A compliant
+	// reader (io.ReadAll via gzip.NewReader) returns an error on such a stream.
+	// This test verifies the stored gzip stream has a valid trailer.
+	original := []byte("tile-payload")
+	srv := setupTileServer(t, "/0/0/0.pbf", original, "")
+	defer srv.Close()
+
+	gen, _ := NewXYZJobGenerator(srv.URL+"/{z}/{x}/{y}.pbf", orb.Bound{}, nil, 5*time.Second, false, true, "pbf")
+	resp := runWorker(t, gen, srv.URL+"/0/0/0.pbf", maptile.New(0, 0, 0))
+
+	gr, err := gzip.NewReader(bytes.NewReader(resp.Data))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	// io.ReadAll propagates the gzip reader's checksum/trailer error; bytes.Buffer.ReadFrom does not.
+	got, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("reading gzip stream: %v (missing CRC32/ISIZE trailer — was Flush used instead of Close?)", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("decompressed mismatch: got %q, want %q", got, original)
 	}
 }

--- a/tilepack/metatile_job_creator.go
+++ b/tilepack/metatile_job_creator.go
@@ -60,6 +60,7 @@ func NewMetatileJobGenerator(bucket string, requesterPays bool, pathTemplate str
 		maxDetailZoom: maxDetailZoom,
 		bounds:        bounds,
 		zooms:         zooms,
+		zoomSet:       zoomSliceToSet(zooms),
 		format:        format,
 	}, nil
 }
@@ -74,14 +75,23 @@ type metatileJobGenerator struct {
 	maxDetailZoom maptile.Zoom
 	bounds        orb.Bound
 	zooms         []maptile.Zoom
+	zoomSet       map[maptile.Zoom]struct{}
 	format        string
 }
 
 func (x *metatileJobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, results chan *TileResponse), error) {
+	// Build zoom set once per worker; guards against direct struct construction in tests.
+	zoomSet := x.zoomSet
+	if zoomSet == nil {
+		zoomSet = zoomSliceToSet(x.zooms)
+	}
 	f := func(id int, jobs chan *TileRequest, results chan *TileResponse) {
 		// Instantiate the gzip support stuff once instead on every iteration
 		bodyBuffer := bytes.NewBuffer(nil)
-		bodyGzipper := gzip.NewWriter(bodyBuffer)
+		bodyGzipper, err := gzip.NewWriterLevel(bodyBuffer, gzip.BestCompression)
+		if err != nil {
+			log.Fatalf("Couldn't create gzipper: %+v", err)
+		}
 
 		for metaTileRequest := range jobs {
 			// Download the metatile archive zip to a byte buffer
@@ -130,7 +140,7 @@ func (x *metatileJobGenerator) CreateWorker() (func(id int, jobs chan *TileReque
 					metaTileRequest.Tile.Z+maptile.Zoom(offsetZ),
 				)
 
-				if !arrayContains(t.Z, x.zooms) {
+				if _, ok := zoomSet[t.Z]; !ok {
 					continue
 				}
 
@@ -183,7 +193,8 @@ func (x *metatileJobGenerator) CreateWorker() (func(id int, jobs chan *TileReque
 }
 
 func (x *metatileJobGenerator) CreateJobs(jobs chan *TileRequest) error {
-	// Convert the list of requested zooms into a list of zooms where metatiles are
+	// Convert the list of requested zooms into a deduplicated list of metatile zooms.
+	seenMetatileZooms := make(map[maptile.Zoom]struct{})
 	metatileZooms := []maptile.Zoom{}
 
 	metaZoom := maptile.Zoom(log2Uint(x.metatileSize))
@@ -203,7 +214,8 @@ func (x *metatileJobGenerator) CreateJobs(jobs chan *TileRequest) error {
 			metatileZoom = x.maxDetailZoom
 		}
 
-		if !arrayContains(metatileZoom, metatileZooms) {
+		if _, seen := seenMetatileZooms[metatileZoom]; !seen {
+			seenMetatileZooms[metatileZoom] = struct{}{}
 			metatileZooms = append(metatileZooms, metatileZoom)
 		}
 	}

--- a/tilepack/pmtiles_outputter.go
+++ b/tilepack/pmtiles_outputter.go
@@ -38,7 +38,7 @@ type offsetLen struct {
 type pmtilesOutputter struct {
 	tileset        *roaring64.Bitmap    // set of all addressed tile IDs (for count reporting)
 	hashFunc       hash.Hash            // FNV-128a; reset per tile for deduplication
-	offsetMap      map[string]offsetLen // hash → position in tileData; drives dedup
+	offsetMap      map[[16]byte]offsetLen // hash → position in tileData; drives dedup
 	dataOffset     uint64               // running byte offset into tileData
 	tileData       *os.File             // temp file accumulating raw tile blobs
 	entries        []pmtiles.EntryV3    // one entry per Save call before RLE
@@ -73,11 +73,13 @@ func (p *pmtilesOutputter) Save(tile maptile.Tile, data []byte) error {
 	p.tileset.Add(id)
 
 	// Hash the raw (pre-compression) bytes for content-based deduplication.
+	// Write the FNV-128a sum into a stack-allocated [16]byte so the map key
+	// never escapes to the heap (one fewer allocation per tile vs. string(h.Sum(nil))).
 	p.hashFunc.Reset()
 	p.hashFunc.Write(data)
-	var empty []byte
-	sumString := string(p.hashFunc.Sum(empty))
-	found, ok := p.offsetMap[sumString]
+	var key [16]byte
+	p.hashFunc.Sum(key[:0])
+	found, ok := p.offsetMap[key]
 
 	if !ok {
 		// New content: compress if needed, append to the temp data file.
@@ -109,7 +111,7 @@ func (p *pmtilesOutputter) Save(tile maptile.Tile, data []byte) error {
 			offset: p.dataOffset,
 			length: uint32(bytesWritten),
 		}
-		p.offsetMap[sumString] = found
+		p.offsetMap[key] = found
 		p.dataOffset += uint64(bytesWritten)
 	}
 
@@ -371,9 +373,10 @@ func optimizeDirectories(entries []pmtiles.EntryV3, targetRootLen int, compressi
 // Each root entry has RunLength=0, which signals to readers that the entry is a
 // leaf-directory pointer rather than a tile-data pointer.
 func buildRootsLeaves(entries []pmtiles.EntryV3, leafSize int, compression pmtiles.Compression) ([]byte, []byte, int) {
-	rootEntries := make([]pmtiles.EntryV3, 0)
+	numLeaves := (len(entries) + leafSize - 1) / leafSize
+	rootEntries := make([]pmtiles.EntryV3, 0, numLeaves)
 	leavesBytes := make([]byte, 0)
-	numLeaves := 0
+	numLeaves = 0
 
 	for i := 0; i < len(entries); i += leafSize {
 		numLeaves++
@@ -431,7 +434,7 @@ func NewPmtilesOutputter(dsn string, outputType string, metadata *MbtilesMetadat
 		tileset:        roaring64.New(),
 		hashFunc:       fnv.New128a(),
 		tileData:       tmpFile,
-		offsetMap:      make(map[string]offsetLen),
+		offsetMap:      make(map[[16]byte]offsetLen),
 		entries:        make([]pmtiles.EntryV3, 0),
 		header:         pmtiles.HeaderV3{},
 		compressBuffer: compressBuf,

--- a/tilepack/pmtiles_outputter.go
+++ b/tilepack/pmtiles_outputter.go
@@ -373,10 +373,10 @@ func optimizeDirectories(entries []pmtiles.EntryV3, targetRootLen int, compressi
 // Each root entry has RunLength=0, which signals to readers that the entry is a
 // leaf-directory pointer rather than a tile-data pointer.
 func buildRootsLeaves(entries []pmtiles.EntryV3, leafSize int, compression pmtiles.Compression) ([]byte, []byte, int) {
-	numLeaves := (len(entries) + leafSize - 1) / leafSize
-	rootEntries := make([]pmtiles.EntryV3, 0, numLeaves)
+	estLeaves := (len(entries) + leafSize - 1) / leafSize
+	rootEntries := make([]pmtiles.EntryV3, 0, estLeaves)
 	leavesBytes := make([]byte, 0)
-	numLeaves = 0
+	numLeaves := 0
 
 	for i := 0; i < len(entries); i += leafSize {
 		numLeaves++

--- a/tilepack/s3_job_creator_test.go
+++ b/tilepack/s3_job_creator_test.go
@@ -382,3 +382,41 @@ func TestT2Worker_SkipsOutOfBounds(t *testing.T) {
 		t.Errorf("expected 0 responses for zoom-filtered tile, got %d", count)
 	}
 }
+
+func TestMetatileWorker_SkipsWrongZoom(t *testing.T) {
+	// Tiles extracted from a metatile whose effective zoom is not in the requested
+	// zoom list must be silently skipped. This exercises the zoomSet filter path.
+	// The metatile request is at z=0; offsetZ=1 makes the extracted tile z=1.
+	rawData := []byte("z1-tile")
+	zipBytes := buildMetatileZip(t, 1, 0, 0, "mvt", rawData) // offsetZ=1 → extracted z=1
+
+	fake := &fakeS3Downloader{objects: map[string][]byte{"0/0/0.zip": zipBytes}}
+	gen := &metatileJobGenerator{
+		s3Client:      fake,
+		bucket:        "b",
+		pathTemplate:  "{z}/{x}/{y}.zip",
+		layerName:     "all",
+		format:        "mvt",
+		metatileSize:  8,
+		maxDetailZoom: 0,
+		bounds:        orb.Bound{Min: orb.Point{-180, -85}, Max: orb.Point{180, 85}},
+		zooms:         []maptile.Zoom{0}, // only zoom 0 — z=1 tile must be dropped
+	}
+
+	jobs := make(chan *TileRequest, 1)
+	results := make(chan *TileResponse, 10)
+	worker, _ := gen.CreateWorker()
+
+	jobs <- &TileRequest{Tile: maptile.New(0, 0, 0), URL: "0/0/0.zip"}
+	close(jobs)
+	worker(0, jobs, results)
+	close(results)
+
+	var count int
+	for range results {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 responses for out-of-zoom-list tile, got %d", count)
+	}
+}

--- a/tilepack/t2_job_creator.go
+++ b/tilepack/t2_job_creator.go
@@ -37,6 +37,7 @@ func NewTapalcatl2JobGenerator(bucket string, requesterPays bool, pathTemplate s
 		materializedZooms: materializedZooms,
 		bounds:            bounds,
 		zooms:             zooms,
+		zoomSet:           zoomSliceToSet(zooms),
 	}, nil
 }
 
@@ -49,6 +50,7 @@ type tapalcatl2JobGenerator struct {
 	materializedZooms []maptile.Zoom
 	bounds            orb.Bound
 	zooms             []maptile.Zoom
+	zoomSet           map[maptile.Zoom]struct{}
 }
 
 func arrayContains(needle maptile.Zoom, haystack []maptile.Zoom) bool {
@@ -60,7 +62,20 @@ func arrayContains(needle maptile.Zoom, haystack []maptile.Zoom) bool {
 	return false
 }
 
+func zoomSliceToSet(zooms []maptile.Zoom) map[maptile.Zoom]struct{} {
+	s := make(map[maptile.Zoom]struct{}, len(zooms))
+	for _, z := range zooms {
+		s[z] = struct{}{}
+	}
+	return s
+}
+
 func (x *tapalcatl2JobGenerator) CreateWorker() (func(id int, jobs chan *TileRequest, results chan *TileResponse), error) {
+	// Build zoom set once per worker; guards against direct struct construction in tests.
+	zoomSet := x.zoomSet
+	if zoomSet == nil {
+		zoomSet = zoomSliceToSet(x.zooms)
+	}
 	f := func(id int, jobs chan *TileRequest, results chan *TileResponse) {
 		for request := range jobs {
 			// Download the Tapalcatl2 archive zip to a byte buffer
@@ -97,7 +112,7 @@ func (x *tapalcatl2JobGenerator) CreateWorker() (func(id int, jobs chan *TileReq
 
 				t := maptile.New(tileX, tileY, tileZ)
 
-				if !arrayContains(tileZ, x.zooms) {
+				if _, ok := zoomSet[tileZ]; !ok {
 					continue
 				}
 


### PR DESCRIPTION
## Summary

- **Fix corrupt gzip output in XYZ worker** (`http_job_creator.go`): `gzip.Flush()` was used instead of `gzip.Close()`, producing streams missing the CRC32/ISIZE trailer. Malformed blobs were silently passed through to PMTiles archives via the already-gzipped fast-path.
- **Fix stale bytes on re-run in disk outputter** (`disk_outputter.go`): `O_RDWR|O_CREATE` without `O_TRUNC` left trailing bytes from a prior write when a tile shrank on re-run. Changed to `O_WRONLY|O_CREATE|O_TRUNC`.
- **Use `gzip.BestCompression` consistently** (`http_job_creator.go`, `metatile_job_creator.go`): Workers used `DefaultCompression` (level 6); the PMTiles outputter's already-gzipped bypass meant tiles were stored at level 6 instead of the intended level 9.
- **Eliminate per-tile heap allocation for hash key** (`pmtiles_outputter.go`): Changed `offsetMap` from `map[string]offsetLen` to `map[[16]byte]offsetLen` and replaced `string(h.Sum(nil))` with `h.Sum(key[:0])` into a stack-allocated `[16]byte`, removing one heap allocation per saved tile.
- **Pre-size `rootEntries` in `buildRootsLeaves`** (`pmtiles_outputter.go`): Number of leaf pages is calculable up front; pre-sizing avoids repeated slice reallocation during directory construction.
- **Replace O(n) `arrayContains` with O(1) map lookup** (`t2_job_creator.go`, `metatile_job_creator.go`): Added `zoomSet map[maptile.Zoom]struct{}` built once at construction; per-tile zoom filter is now O(1).

## Test plan

- [x] `go test ./...` passes
- [ ] Manually verify a PMTiles archive built from XYZ tiles decompresses tiles correctly (gzip trailer now present)
- [ ] Re-run disk outputter over same output directory and verify tile files are not corrupted